### PR TITLE
Add logging

### DIFF
--- a/R/OptimInstance.R
+++ b/R/OptimInstance.R
@@ -12,7 +12,7 @@
 #'
 #' @section Technical details:
 #'
-#' In order the replace the default logging messages with custom logging, the
+#' In order to replace the default logging messages with custom logging, the
 #' `.log_*` private methods can be overwritten in an `OptimInstance` subclass:
 #'
 #' * `$.log_eval_batch_start()` Called at the beginning of `$eval_batch()`
@@ -92,7 +92,7 @@ OptimInstance = R6Class("OptimInstance",
       private$.log_eval_batch_start(xdt)
       ydt = self$objective$eval_many(xss_trafoed)
       self$archive$add_evals(xdt, xss_trafoed, ydt)
-      private$.log_eval_batch_finish()
+      private$.log_eval_batch_finish(xdt, ydt)
       return(invisible(ydt))
     },
 
@@ -150,10 +150,9 @@ OptimInstance = R6Class("OptimInstance",
       lg$info("Evaluating %i configuration(s)", nrow(xdt))
     },
 
-    .log_eval_batch_finish = function() {
+    .log_eval_batch_finish = function(xdt, ydt) {
       lg$info("Result of batch %i:", self$archive$n_batch)
-      lg$info(capture.output(print(
-        self$archive$data[batch_nr == self$archive$n_batch, ],
+      lg$info(capture.output(print(cbind(xdt, ydt),
         class = FALSE, row.names = FALSE, print.keys = FALSE)))
     }
   )

--- a/R/Optimizer.R
+++ b/R/Optimizer.R
@@ -11,7 +11,7 @@
 #'
 #' @section Technical details:
 #'
-#' In order the replace the default logging messages with custom logging, the
+#' In order to replace the default logging messages with custom logging, the
 #' `.log_*` private methods can be overwritten in an `Optimizer` subclass:
 #'
 #' * `$.log_optimize_start()` Called at the beginning of `$optimize()`

--- a/R/Optimizer.R
+++ b/R/Optimizer.R
@@ -9,6 +9,14 @@
 #' of the [OptimInstance] at the end in order to store the best point  and its
 #' estimated performance vector.
 #'
+#' @section Technical details:
+#'
+#' In order the replace the default logging messages with custom logging, the
+#' `.log_*` private methods can be overwritten in an `Optimizer` subclass:
+#'
+#' * `$.log_optimize_start()` Called at the beginning of `$optimize()`
+#' * `$.log_optimize_finish()` Called at the end of `$optimize()`
+#'
 #' @export
 Optimizer = R6Class("Optimizer",
   public = list(
@@ -64,6 +72,7 @@ Optimizer = R6Class("Optimizer",
     #' @param inst ([OptimInstance]).
     #' @return NULL
     optimize = function(inst) {
+
       assert_r6(inst, "OptimInstance")
       require_namespaces(self$packages, "Packages for the Optimization")
       # check dependencies
@@ -78,13 +87,15 @@ Optimizer = R6Class("Optimizer",
         self$param_classes)
       if (length(not_supported_pclasses) > 0L) {
         stopf(
-          "Tuner '%s' does not support param types: '%s'", class(self)[1L],
+          "Optimizer '%s' does not support param types: '%s'", class(self)[1L],
           paste0(not_supported_pclasses, collapse = ","))
       }
+      private$.log_optimize_start(inst)
       tryCatch({
         private$.optimize(inst)
       }, terminated_error = function(cond) { })
       private$.assign_result(inst)
+      private$.log_optimize_finish(inst)
       invisible(NULL)
     }
   ),
@@ -97,10 +108,23 @@ Optimizer = R6Class("Optimizer",
       res = inst$archive$get_best()
 
       xdt = res[, inst$search_space$ids(), with = FALSE]
-      y = unlist(res[, inst$objective$codomain$ids(), with = FALSE]) #unlist keeps name!
+      y = unlist(res[, inst$objective$codomain$ids(), with = FALSE]) # unlist keeps name!
 
       inst$assign_result(xdt, y)
       invisible(NULL)
+    },
+
+    .log_optimize_start = function(inst) {
+      lg$info("Starting to optimize %i parameter(s) with '%s' and '%s'",
+        inst$search_space$length, self$format(), inst$terminator$format())
+    },
+
+    .log_optimize_finish = function(inst) {
+      lg$info("Finished optimizing after %i evaluation(s)",
+        inst$archive$n_evals)
+      lg$info("Result:")
+      lg$info(capture.output(print(
+        inst$result, lass = FALSE, row.names = FALSE, print.keys = FALSE)))
     }
   )
 )

--- a/man/OptimInstance.Rd
+++ b/man/OptimInstance.Rd
@@ -15,13 +15,14 @@ point on.
 }
 }
 \section{Technical details}{
+
 The \link{Optimizer} writes the final result to the \code{.result} field by using
 the \verb{$assign_result()} method. \code{.result} stores a \link[data.table:data.table]{data.table::data.table}
 consisting of x values in the \emph{search space}, (transformed) x values in the
 \emph{domain space} and y values in the \emph{codomain space} of the \link{Objective}. The
 user can access the results with active bindings (see below).
-  
- In order to replace the default logging messages with custom logging, the
+
+In order to replace the default logging messages with custom logging, the
 \verb{.log_*} private methods can be overwritten in an \code{OptimInstance} subclass:
 \itemize{
 \item \verb{$.log_eval_batch_start()} Called at the beginning of \verb{$eval_batch()}

--- a/man/OptimInstance.Rd
+++ b/man/OptimInstance.Rd
@@ -17,7 +17,7 @@ point on.
 \section{Technical details}{
 
 
-In order the replace the default logging messages with custom logging, the
+In order to replace the default logging messages with custom logging, the
 \verb{.log_*} private methods can be overwritten in an \code{OptimInstance} subclass:
 \itemize{
 \item \verb{$.log_eval_batch_start()} Called at the beginning of \verb{$eval_batch()}

--- a/man/OptimInstance.Rd
+++ b/man/OptimInstance.Rd
@@ -14,6 +14,17 @@ exception is raised, and no further evaluations can be performed from this
 point on.
 }
 }
+\section{Technical details}{
+
+
+In order the replace the default logging messages with custom logging, the
+\verb{.log_*} private methods can be overwritten in an \code{OptimInstance} subclass:
+\itemize{
+\item \verb{$.log_eval_batch_start()} Called at the beginning of \verb{$eval_batch()}
+\item \verb{$.log_eval_batch_finish()} Called at the end of \verb{$eval_batch()}
+}
+}
+
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{

--- a/man/Optimizer.Rd
+++ b/man/Optimizer.Rd
@@ -12,6 +12,17 @@ A \code{Optimizer} object must write its result to the \verb{$assign_result()} m
 of the \link{OptimInstance} at the end in order to store the best point  and its
 estimated performance vector.
 }
+\section{Technical details}{
+
+
+In order the replace the default logging messages with custom logging, the
+\verb{.log_*} private methods can be overwritten in an \code{Optimizer} subclass:
+\itemize{
+\item \verb{$.log_optimize_start()} Called at the beginning of \verb{$optimize()}
+\item \verb{$.log_optimize_finish()} Called at the end of \verb{$optimize()}
+}
+}
+
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{

--- a/man/Optimizer.Rd
+++ b/man/Optimizer.Rd
@@ -15,7 +15,7 @@ estimated performance vector.
 \section{Technical details}{
 
 
-In order the replace the default logging messages with custom logging, the
+In order to replace the default logging messages with custom logging, the
 \verb{.log_*} private methods can be overwritten in an \code{Optimizer} subclass:
 \itemize{
 \item \verb{$.log_optimize_start()} Called at the beginning of \verb{$optimize()}


### PR DESCRIPTION
Closes #54 and #17 

## Proposal

Adds logging to `OptimInstance` and `Optimize`. The logging takes place in private methods so that `mlr3tuning` and `mlr3fselect` can print custom logging messages without completely overwriting `$eval_batch()` and `$optimize()`. Logging could be also added to `$add_evals()` each time something is added to the archive.

Alternative solution would be to add the logging directly to  `$eval_batch()` and `$optimize()`.

## Example

```
library(bbotk)
library(paradox)
source("tests/testthat/helper.R")
opt = OptimizerRandomSearch$new()
opt$param_set$values$batch_size = 5
inst = MAKE_INST(terminator = 10L)
opt$optimize(inst)
```

Prints

```
INFO  [11:33:00.772] Starting to optimize 2 parameter(s) with '<OptimizerRandomSearch>' and '<TerminatorEvals>' 
INFO  [11:33:00.792] Evaluating 5 configuration(s) 
INFO  [11:33:00.802] Result of batch 1: 
INFO  [11:33:00.807]          x1          x2         y  opt_x  timestamp batch_nr 
INFO  [11:33:00.807]   0.3097678 -0.71591903 0.6084961 <list> 1591176780        1 
INFO  [11:33:00.807]   0.5856386 -0.73536490 0.8837342 <list> 1591176780        1 
INFO  [11:33:00.807]  -0.6823273 -0.44943231 0.6675599 <list> 1591176780        1 
INFO  [11:33:00.807]   0.7426086 -0.07036697 0.5564190 <list> 1591176780        1 
INFO  [11:33:00.807]   0.4780475  0.17024974 0.2575144 <list> 1591176780        1 
INFO  [11:33:00.817] Evaluating 5 configuration(s) 
INFO  [11:33:00.825] Result of batch 2: 
INFO  [11:33:00.831]          x1          x2          y  opt_x  timestamp batch_nr 
INFO  [11:33:00.831]  -0.1563215 -0.76575316 0.61081432 <list> 1591176780        2 
INFO  [11:33:00.831]  -0.1988271  0.73103311 0.57394161 <list> 1591176780        2 
INFO  [11:33:00.831]  -0.1741352  0.66426743 0.47157428 <list> 1591176780        2 
INFO  [11:33:00.831]   0.1957138 -0.04273802 0.04013041 <list> 1591176780        2 
INFO  [11:33:00.831]  -0.8102147 -0.34949070 0.77859160 <list> 1591176780        2 
INFO  [11:33:00.844] Finished optimizing after 10 evaluation(s) 
INFO  [11:33:00.846] Result: 
INFO  [11:33:00.849]         x1          x2  opt_x          y 
INFO  [11:33:00.849]  0.1957138 -0.04273802 <list> 0.04013041 
```
