### PR TITLE
NAs in ydt throw an error

### DIFF
--- a/R/Archive.R
+++ b/R/Archive.R
@@ -49,6 +49,9 @@ Archive = R6Class("Archive",
       assert_data_table(xdt)
       assert_data_table(ydt)
       assert_list(xss_trafoed)
+      map(ydt[, self$codomain$ids(), with = FALSE], function(y) {
+        assert_numeric(y, any.missing = FALSE)
+      })
       xydt = cbind(xdt, ydt)
       assert_subset(c(self$search_space$ids(), self$codomain$ids()), colnames(xydt))
       xydt[, "opt_x" := list(xss_trafoed)]

--- a/R/Archive.R
+++ b/R/Archive.R
@@ -49,7 +49,7 @@ Archive = R6Class("Archive",
       assert_data_table(xdt)
       assert_data_table(ydt)
       assert_list(xss_trafoed)
-      map(ydt[, self$codomain$ids(), with = FALSE], function(y) {
+      map(ydt[, self$cols_y, with = FALSE], function(y) {
         assert_numeric(y, any.missing = FALSE)
       })
       xydt = cbind(xdt, ydt)

--- a/R/Archive.R
+++ b/R/Archive.R
@@ -52,8 +52,7 @@ Archive = R6Class("Archive",
       xydt = cbind(xdt, ydt)
       assert_subset(c(self$search_space$ids(), self$codomain$ids()), colnames(xydt))
       xydt[, "opt_x" := list(xss_trafoed)]
-      # FIXME: this will break in 2038
-      xydt[, "timestamp" := as.integer(Sys.time())]
+      xydt[, "timestamp" := Sys.time()]
       batch_nr = self$data$batch_nr
       batch_nr = if (length(batch_nr)) max(batch_nr) + 1L else 1L
       xydt[, "batch_nr" := batch_nr]

--- a/R/Archive.R
+++ b/R/Archive.R
@@ -43,9 +43,6 @@ Archive = R6Class("Archive",
     #'
     #' @param xss_trafoed (`list()`).
     add_evals = function(xdt, xss_trafoed, ydt) {
-
-      # FIXME: add checks here for the dts and their domains
-      # FIXME: make asserts better!
       assert_data_table(xdt)
       assert_data_table(ydt)
       assert_list(xss_trafoed)

--- a/R/Archive.R
+++ b/R/Archive.R
@@ -46,9 +46,7 @@ Archive = R6Class("Archive",
       assert_data_table(xdt)
       assert_data_table(ydt)
       assert_list(xss_trafoed)
-      map(ydt[, self$cols_y, with = FALSE], function(y) {
-        assert_numeric(y, any.missing = FALSE)
-      })
+      assert_data_table(ydt[, self$cols_y, with = FALSE], any.missing = FALSE)
       xydt = cbind(xdt, ydt)
       assert_subset(c(self$search_space$ids(), self$codomain$ids()), colnames(xydt))
       xydt[, "opt_x" := list(xss_trafoed)]

--- a/tests/testthat/test_Archive.R
+++ b/tests/testthat/test_Archive.R
@@ -38,3 +38,12 @@ test_that("Unnest columns", {
   expect_equal(a$opt_x_x1, 1)
   expect_equal(a$opt_x_x2, 2)
 })
+
+test_that("NAs in ydt throw an error", {
+  a = Archive$new(PS_1D, FUN_1D_CODOMAIN)
+  xdt = data.table(x = 1)
+  xss_trafoed = list(list(x = 1))
+  ydt = data.table(y = NA)
+  expect_error(a$add_evals(xdt, xss_trafoed, ydt))
+})
+


### PR DESCRIPTION
Closes #57

```
Assertion on 'y' failed: Contains missing values (element 1). 
```

Is this enough or do we need a more informative message for the user?