### PR TITLE
mlr3 logger

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -9,7 +9,14 @@
 .onLoad = function(libname, pkgname) {
   # nocov start
 
-  assign("lg", lgr::get_logger("mlr3/bbotk"), envir = parent.env(environment()))
+  if(isNamespaceLoaded("mlr3tuning")) {
+    assign("lg", lgr::get_logger("mlr3/mlr3tuning"), envir = parent.env(environment()))
+  } else if (isNamespaceLoaded("mlr3fselect")) {
+    assign("lg", lgr::get_logger("mlr3/mlr3fselect"), envir = parent.env(environment()))
+  } else {
+    assign("lg", lgr::get_logger("bbotk"), envir = parent.env(environment()))
+  }
+
   if (Sys.getenv("IN_PKGDOWN") == "true") {
     lg$set_threshold("warn")
   }


### PR DESCRIPTION
Closes #69

The mlr3/mlr3tuning loggers are used if mlr3tuning is loaded before bbotk. If just bbotk is loaded a logger named bbotk is used.