### PR TITLE
add feature: constants in objective

### DIFF
--- a/R/Objective.R
+++ b/R/Objective.R
@@ -30,6 +30,10 @@ Objective = R6Class("Objective",
     #' Specifies codomain of function, hence its feasible values.
     codomain = NULL,
 
+    #' @field constants ([paradox::ParamSet]).\cr
+    #' Changeable constants or parameters that are not subject to tuning can be stored and accessed here.
+    constants = NULL,
+
     #' @field check_values (`logical(1)`)\cr
     check_values = NULL,
 
@@ -43,11 +47,12 @@ Objective = R6Class("Objective",
     #' validity?
     initialize = function(id = "f", properties = character(), domain,
       codomain = ParamSet$new(list(ParamDbl$new("y", tags = "minimize"))),
-      check_values = TRUE) {
+      constants = ParamSet$new(), check_values = TRUE) {
       self$id = assert_string(id)
       self$domain = assert_param_set(domain)
       self$codomain = assert_codomain(codomain)
       self$properties = assert_subset(properties, bbotk_reflections$objective_properties)
+      self$constants = assert_param_set(constants)
       self$check_values = assert_flag(check_values)
     },
 
@@ -67,6 +72,10 @@ Objective = R6Class("Objective",
       print(self$domain)
       catf("Codomain:")
       print(self$codomain)
+      if (length(self$constants$values) > 0) {
+        catf("Constants:")
+        print(self$constants)
+      }
     },
 
     #' @description

--- a/R/ObjectiveRFun.R
+++ b/R/ObjectiveRFun.R
@@ -46,14 +46,14 @@ ObjectiveRFun = R6Class("ObjectiveRFun",
     #' @param id (`character(1)`).
     #' @param properties (`character()`).
     initialize = function(fun, domain, codomain = NULL, id = "function",
-      properties = character()) {
+      properties = character(), constants = ParamSet$new(), check_values = TRUE) {
       if (is.null(codomain)) {
         codomain = ParamSet$new(list(ParamDbl$new("y", tags = "minimize")))
       }
       private$.fun = assert_function(fun, "xs")
       # asserts id, domain, codomain, properties
       super$initialize(id = id, domain = domain, codomain = codomain,
-        properties = properties)
+        properties = properties, constants = constants, check_values = check_values)
     },
 
     #' @description

--- a/R/ObjectiveRFunDt.R
+++ b/R/ObjectiveRFunDt.R
@@ -20,14 +20,14 @@ ObjectiveRFunDt = R6Class("ObjectiveRFunDt",
     #' @param id (`character(1)`).
     #' @param properties (`character()`).
     initialize = function(fun, domain, codomain = NULL, id = "function",
-      properties = character()) {
+      properties = character(), constants = ParamSet$new(), check_values = TRUE) {
       if (is.null(codomain)) {
         codomain = ParamSet$new(list(ParamDbl$new("y", tags = "minimize")))
       }
       private$.fun = assert_function(fun, "xdt")
       # asserts id, domain, codomain, properties
       super$initialize(id = id, domain = domain, codomain = codomain,
-        properties = properties)
+        properties = properties, constants = constants, check_values = check_values)
     },
 
     #' @description

--- a/man/Objective.Rd
+++ b/man/Objective.Rd
@@ -27,6 +27,9 @@ and ranges.}
 \item{\code{codomain}}{(\link[paradox:ParamSet]{paradox::ParamSet})\cr
 Specifies codomain of function, hence its feasible values.}
 
+\item{\code{constants}}{(\link[paradox:ParamSet]{paradox::ParamSet}).\cr
+Changeable constants or parameters that are not subject to tuning can be stored and accessed here.}
+
 \item{\code{check_values}}{(\code{logical(1)})\cr}
 }
 \if{html}{\out{</div>}}
@@ -65,6 +68,7 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
   properties = character(),
   domain,
   codomain = ParamSet$new(list(ParamDbl$new("y", tags = "minimize"))),
+  constants = ParamSet$new(),
   check_values = TRUE
 )}\if{html}{\out{</div>}}
 }


### PR DESCRIPTION
We could also use the values in constants to store parameters that we pass to `.fun()` in `ObjectiveRFun` and `ObjectiveRFunDt`.