### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/tests/testthat/test_Optimizer.R
+++ b/tests/testthat/test_Optimizer.R
@@ -9,7 +9,7 @@ test_that("Optimizer assertions work", {
   instance = MAKE_INST_2D(terminator = terminator)
   expect_error(optimizer$optimize(instance), "does not support single-crit objectives")
 
-  optimizer = expect_warning(MAKE_OPT(packages = "foo"), "'foo' required but not installed")
+  expect_warning({ optimizer = MAKE_OPT(packages = "foo") }, "'foo' required but not installed")
   terminator = trm("evals")
   instance = MAKE_INST_2D(terminator = terminator)
   expect_error(optimizer$optimize(instance), class = "packageNotFoundError")


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
