### PR TITLE
fix: parameters of GenSA

### DIFF
--- a/R/OptimizerGenSA.R
+++ b/R/OptimizerGenSA.R
@@ -68,11 +68,13 @@ OptimizerGenSA = R6Class("OptimizerGenSA", inherit = Optimizer,
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function() {
       param_set = ps(
-        smooth = p_lgl(default = TRUE),
+        smooth = p_lgl(default = TRUE),  # FIXME: probably switch this to FALSE
         temperature = p_dbl(default = 5230),
+        visiting.param = p_dbl(default = 2.62),
         acceptance.param = p_dbl(default = -5),
+        simple.function = p_lgl(default = FALSE),
         verbose = p_lgl(default = FALSE),
-        trace.mat = p_lgl(default = TRUE)
+        trace.mat = p_lgl(default = FALSE)
       )
       super$initialize(
         id = "gensa",
@@ -89,7 +91,8 @@ OptimizerGenSA = R6Class("OptimizerGenSA", inherit = Optimizer,
   private = list(
     .optimize = function(inst) {
       v = self$param_set$values
-      v$maxit = .Machine$integer.max # make sure GenSA does not stop
+      v$maxit = .Machine$integer.max  # make sure GenSA does not stop
+      v$nb.stop.improvement = .Machine$integer.max   # make sure GenSA does not stop
       GenSA::GenSA(par = NULL, fn = inst$objective_function,
         lower = inst$search_space$lower, upper = inst$search_space$upper,
         control = v)

--- a/man/mlr_optimizers_gensa.Rd
+++ b/man/mlr_optimizers_gensa.Rd
@@ -40,6 +40,11 @@ opt("gensa")
 For the meaning of the control parameters, see \code{\link[GenSA:GenSA]{GenSA::GenSA()}}. Note that we
 have removed all control parameters which refer to the termination of the
 algorithm and where our terminators allow to obtain the same behavior.
+
+In contrast to the \code{\link[GenSA:GenSA]{GenSA::GenSA()}} defaults, we set \code{trace.mat = FALSE}.
+Note that \code{\link[GenSA:GenSA]{GenSA::GenSA()}} uses \code{smooth = TRUE} as a default.
+In the case of using this optimizer for Hyperparameter Optimization you may
+want to set \code{smooth = FALSE}.
 }
 
 \section{Progress Bars}{
@@ -71,7 +76,7 @@ if (requireNamespace("GenSA")) {
     search_space = search_space,
     terminator = trm("evals", n_evals = 10))
 
-  optimizer = opt("cmaes")
+  optimizer = opt("gensa")
 
   # Modifies the instance by reference
   optimizer$optimize(instance)


### PR DESCRIPTION
* Parameters `visiting.param` and `simple.function` were missing
* Also set `trace.mat = FALSE` because we dont' need this
* Added a comment on `smooth` in the docs because most of the time you may want this to be `FALSE` (but GenSA default is `TRUE`).

Did a small benchmark on xgboost comparing some optimizers on 2D, 3D, 5D problems on 10 tasks and default GenSA performs very poorly (y-axis is mean normalized regret over the mean of the 10 repls over the 30 problems in total):

![image](https://user-images.githubusercontent.com/17437765/175541173-e731b3c9-e6d3-4360-af04-fefdbf74947a.png)

Small ablation on 3 of the problems where GenSA performed worst shows that if you set `smooth = FALSE` you get quite some performance boosts (GenSAv2 or GenSAv4; GenSAv3 is the current default):

![image](https://user-images.githubusercontent.com/17437765/175541498-b5fd30ed-08bd-46e4-8285-a84fa9a3e416.png)

The four versions are constructed w.r.t `smooth` and `simple.function` (full factorial design: v1 TRUE/TRUE, v2 FALSE/TRUE, v3 TRUE/FALSE, v4 FALSE/FALSE) but `simple.function` does not have a strong effect.

`smooth` is not really explained in the docs of GenSA but what happens is:
If `FALSE` switches the local search algorithm from using L-BFGS-B (default) to Nelder-Mead that works better when the objective function has very few places where numerical derivatives can be computed.
I would say that numerical derivatives are quite hard to compute in HPO problems (noisy, resampling, etc.) and therefore argue to go with `smooth = FALSE` (in mlr3tuning; here in bbotk I suggest we keep things as before but I added a comment in the docs).
