### PR TITLE
docs: adjust formatting of TerminatorEvals formula

### DIFF
--- a/R/TerminatorEvals.R
+++ b/R/TerminatorEvals.R
@@ -9,7 +9,7 @@
 #' The total number of evaluations \eqn{B} is defined as
 #'
 #' \deqn{
-#'    B = \mathrm{n_evals} + k * D
+#'    B = \mathtt{n\_evals} + \mathtt{k} * D
 #' }{
 #'    B = n_evals + k * D
 #' }


### PR DESCRIPTION
`n_evals` showed up as $n_evals$, I adjusted it to $\mathtt{n\\_evals}$, avoiding the subscript for readibility.