### PR TITLE
test: tolerate condition column in ArchiveAsync as.data.table test

### DIFF
--- a/tests/testthat/test_ArchiveAsync.R
+++ b/tests/testthat/test_ArchiveAsync.R
@@ -123,7 +123,8 @@ test_that("as.data.table.ArchiveAsync works", {
   expect_data_table(data, min.rows = 5)
 
   cns = c("state", "x1", "x2", "y", "timestamp_xs", "worker_id", "timestamp_ys", "keys", "x_domain_x1", "x_domain_x2")
-  expect_names(colnames(data), identical.to = cns)
+  # a failed task adds a "condition" column
+  expect_names(setdiff(colnames(data), "condition"), identical.to = cns)
 
   data = as.data.table(instance$archive, unnest = NULL)
   expect_list(data$x_domain)


### PR DESCRIPTION
When a task fails, rush adds a `condition` column to the archive data returned by `as.data.table(ArchiveAsync)` (via `data_with_state()`, whose fields include `"condition"`). The column-name check in `test_ArchiveAsync.R` used `identical.to`, which fails whenever a task happens to fail and the extra column appears.

This relaxes the check to ignore the optional `condition` column while still verifying the exact set and order of the remaining columns.

Same class of flakiness fixed in mlr3tuning. Checked mlr3mbo and mlr3hyperband too: their async archive tests already use tolerant `must.include` checks (or access individual columns), so no changes are needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)