### PR TITLE
refactor: remove deprecated extra argument from ArchiveAsync

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     progressr,
     redux,
     RhpcBLASctl,
-    rush (>= 1.0.0),
+    rush (>= 1.2.0),
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Config/testthat/parallel: false

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # bbotk (development version)
 
+* refactor: Remove the deprecated `extra` argument from `ArchiveAsync`'s `$push_points()`, `$push_point()`, `$push_running_points()`, `$push_running_point()`, `$finish_points()`, and `$finish_point()`.
+  Use the corresponding `xss_extra`, `xs_extra`, or `yss_extra`, `ys_extra` argument instead.
+
 # bbotk 1.11.0
 
 * fix: Asynchronous optimization no longer calls the deprecated `rush$fail_tasks()` method when cleaning up after termination.

--- a/R/ArchiveAsync.R
+++ b/R/ArchiveAsync.R
@@ -100,11 +100,7 @@ ArchiveAsync = R6Class(
     #' List of named lists of point values.
     #' @param xss_extra (list of named `list()` | `NULL`)\cr
     #' List of named lists of additional information.
-    #' @param extra (list of named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `xss_extra` instead.
-    push_points = function(xss, xss_extra = NULL, extra = NULL) {
-      xss_extra = xss_extra %??% extra
+    push_points = function(xss, xss_extra = NULL) {
       if (self$check_values) {
         map(xss, self$search_space$assert)
       }
@@ -124,11 +120,7 @@ ArchiveAsync = R6Class(
     #' Named list of point values.
     #' @param xs_extra (named `list()` | `NULL`)\cr
     #' Named list of additional information.
-    #' @param extra (named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `xs_extra` instead.
-    push_point = function(xs, xs_extra = NULL, extra = NULL) {
-      xs_extra = xs_extra %??% extra
+    push_point = function(xs, xs_extra = NULL) {
       if (self$check_values) {
         self$search_space$assert(xs)
       }
@@ -143,11 +135,7 @@ ArchiveAsync = R6Class(
     #' List of named lists of point values.
     #' @param xss_extra (list of named `list()` | `NULL`)\cr
     #' List of named lists of additional information.
-    #' @param extra (list of named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `xss_extra` instead.
-    push_running_points = function(xss, xss_extra = NULL, extra = NULL) {
-      xss_extra = xss_extra %??% extra
+    push_running_points = function(xss, xss_extra = NULL) {
       if (self$check_values) {
         map(xss, self$search_space$assert)
       }
@@ -167,11 +155,7 @@ ArchiveAsync = R6Class(
     #' Named list of point values.
     #' @param xs_extra (named `list()` | `NULL`)\cr
     #' Named list of additional information.
-    #' @param extra (named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `xs_extra` instead.
-    push_running_point = function(xs, xs_extra = NULL, extra = NULL) {
-      xs_extra = xs_extra %??% extra
+    push_running_point = function(xs, xs_extra = NULL) {
       if (self$check_values) {
         self$search_space$assert(xs)
       }
@@ -278,11 +262,7 @@ ArchiveAsync = R6Class(
     #' List of named lists of transformed point values.
     #' @param yss_extra (list of named `list()` | `NULL`)\cr
     #' List of named lists of additional information.
-    #' @param extra (list of named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `yss_extra` instead.
-    finish_points = function(keys, yss, x_domains, yss_extra = NULL, extra = NULL) {
-      yss_extra = yss_extra %??% extra
+    finish_points = function(keys, yss, x_domains, yss_extra = NULL) {
       timestamp_ys = Sys.time()
       yss_extra = if (is.null(yss_extra)) {
         map(x_domains, function(x_domain) list(x_domain = list(x_domain), timestamp_ys = timestamp_ys))
@@ -305,11 +285,7 @@ ArchiveAsync = R6Class(
     #' Named list of transformed point values.
     #' @param ys_extra (named `list()` | `NULL`)\cr
     #' Named list of additional information.
-    #' @param extra (named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `ys_extra` instead.
-    finish_point = function(key, ys, x_domain, ys_extra = NULL, extra = NULL) {
-      ys_extra = ys_extra %??% extra
+    finish_point = function(key, ys, x_domain, ys_extra = NULL) {
       ys_extra = c(list(x_domain = list(x_domain), timestamp_ys = Sys.time()), ys_extra)
       self$rush$finish_tasks(key, list(ys), extra = list(ys_extra))
     },
@@ -353,7 +329,7 @@ ArchiveAsync = R6Class(
     #' Named list of additional information.
     push_result = function(key, ys, x_domain, extra = NULL) {
       .Deprecated(new = "finish_point", old = "push_result")
-      self$finish_point(key, ys, x_domain, extra = extra)
+      self$finish_point(key, ys, x_domain, ys_extra = extra)
     },
 
     #' @description

--- a/R/ArchiveAsyncFrozen.R
+++ b/R/ArchiveAsyncFrozen.R
@@ -92,10 +92,7 @@ ArchiveAsyncFrozen = R6Class(
     #' List of named lists of point values.
     #' @param xss_extra (list of named `list()` | `NULL`)\cr
     #' List of named lists of additional information.
-    #' @param extra (list of named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `xss_extra` instead.
-    push_points = function(xss, xss_extra = NULL, extra = NULL) {
+    push_points = function(xss, xss_extra = NULL) {
       stop("Archive is frozen")
     },
 
@@ -106,10 +103,7 @@ ArchiveAsyncFrozen = R6Class(
     #' Named list of point values.
     #' @param xs_extra (named `list()` | `NULL`)\cr
     #' Named list of additional information.
-    #' @param extra (named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `xs_extra` instead.
-    push_point = function(xs, xs_extra = NULL, extra = NULL) {
+    push_point = function(xs, xs_extra = NULL) {
       stop("Archive is frozen")
     },
 
@@ -120,10 +114,7 @@ ArchiveAsyncFrozen = R6Class(
     #' List of named lists of point values.
     #' @param xss_extra (list of named `list()` | `NULL`)\cr
     #' List of named lists of additional information.
-    #' @param extra (list of named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `xss_extra` instead.
-    push_running_points = function(xss, xss_extra = NULL, extra = NULL) {
+    push_running_points = function(xss, xss_extra = NULL) {
       stop("Archive is frozen")
     },
 
@@ -134,10 +125,7 @@ ArchiveAsyncFrozen = R6Class(
     #' Named list of point values.
     #' @param xs_extra (named `list()` | `NULL`)\cr
     #' Named list of additional information.
-    #' @param extra (named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `xs_extra` instead.
-    push_running_point = function(xs, xs_extra = NULL, extra = NULL) {
+    push_running_point = function(xs, xs_extra = NULL) {
       stop("Archive is frozen")
     },
 
@@ -216,10 +204,7 @@ ArchiveAsyncFrozen = R6Class(
     #' List of named lists of transformed point values.
     #' @param yss_extra (list of named `list()` | `NULL`)\cr
     #' List of named lists of additional information.
-    #' @param extra (list of named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `yss_extra` instead.
-    finish_points = function(keys, yss, x_domains, yss_extra = NULL, extra = NULL) {
+    finish_points = function(keys, yss, x_domains, yss_extra = NULL) {
       stop("Archive is frozen")
     },
 
@@ -234,10 +219,7 @@ ArchiveAsyncFrozen = R6Class(
     #' Named list of transformed point values.
     #' @param ys_extra (named `list()` | `NULL`)\cr
     #' Named list of additional information.
-    #' @param extra (named `list()` | `NULL`)\cr
-    #' Deprecated argument for additional information.
-    #' Use `ys_extra` instead.
-    finish_point = function(key, ys, x_domain, ys_extra = NULL, extra = NULL) {
+    finish_point = function(key, ys, x_domain, ys_extra = NULL) {
       stop("Archive is frozen")
     },
 

--- a/R/OptimInstanceAsync.R
+++ b/R/OptimInstanceAsync.R
@@ -117,7 +117,7 @@ OptimInstanceAsync = R6Class(
       call_back("on_optimizer_after_eval", self$objective$callbacks, self$objective$context)
 
       # push result
-      self$archive$finish_point(key, private$.ys, x_domain = private$.xs_trafoed, extra = private$.extra)
+      self$archive$finish_point(key, private$.ys, x_domain = private$.xs_trafoed, ys_extra = private$.extra)
 
       invisible(private$.ys)
     },

--- a/man/ArchiveAsync.Rd
+++ b/man/ArchiveAsync.Rd
@@ -188,7 +188,7 @@ If a rush instance is supplied, the tuning runs without batches.}
   Push queued points to the archive.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsync$push_points(xss, xss_extra = NULL, extra = NULL)}
+    \preformatted{ArchiveAsync$push_points(xss, xss_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -198,9 +198,6 @@ If a rush instance is supplied, the tuning runs without batches.}
 List of named lists of point values.}
       \item{\code{xss_extra}}{(list of named \code{list()} | \code{NULL})\cr
 List of named lists of additional information.}
-      \item{\code{extra}}{(list of named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{xss_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }
@@ -213,7 +210,7 @@ Use \code{xss_extra} instead.}
   Push a single queued point to the archive.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsync$push_point(xs, xs_extra = NULL, extra = NULL)}
+    \preformatted{ArchiveAsync$push_point(xs, xs_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -223,9 +220,6 @@ Use \code{xss_extra} instead.}
 Named list of point values.}
       \item{\code{xs_extra}}{(named \code{list()} | \code{NULL})\cr
 Named list of additional information.}
-      \item{\code{extra}}{(named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{xs_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }
@@ -238,7 +232,7 @@ Use \code{xs_extra} instead.}
   Push running points to the archive.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsync$push_running_points(xss, xss_extra = NULL, extra = NULL)}
+    \preformatted{ArchiveAsync$push_running_points(xss, xss_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -248,9 +242,6 @@ Use \code{xs_extra} instead.}
 List of named lists of point values.}
       \item{\code{xss_extra}}{(list of named \code{list()} | \code{NULL})\cr
 List of named lists of additional information.}
-      \item{\code{extra}}{(list of named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{xss_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }
@@ -263,7 +254,7 @@ Use \code{xss_extra} instead.}
   Push running point to the archive.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsync$push_running_point(xs, xs_extra = NULL, extra = NULL)}
+    \preformatted{ArchiveAsync$push_running_point(xs, xs_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -273,9 +264,6 @@ Use \code{xss_extra} instead.}
 Named list of point values.}
       \item{\code{xs_extra}}{(named \code{list()} | \code{NULL})\cr
 Named list of additional information.}
-      \item{\code{extra}}{(named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{xs_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }
@@ -402,13 +390,7 @@ If \code{NULL}, a generic error message is used.}
   Save the results of multiple running points and move them to the finished points.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsync$finish_points(
-  keys,
-  yss,
-  x_domains,
-  yss_extra = NULL,
-  extra = NULL
-)}
+    \preformatted{ArchiveAsync$finish_points(keys, yss, x_domains, yss_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -422,9 +404,6 @@ List of named lists of results.}
 List of named lists of transformed point values.}
       \item{\code{yss_extra}}{(list of named \code{list()} | \code{NULL})\cr
 List of named lists of additional information.}
-      \item{\code{extra}}{(list of named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{yss_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }
@@ -437,7 +416,7 @@ Use \code{yss_extra} instead.}
   Save the results of a running point and move it to the finished points.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsync$finish_point(key, ys, x_domain, ys_extra = NULL, extra = NULL)}
+    \preformatted{ArchiveAsync$finish_point(key, ys, x_domain, ys_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -451,9 +430,6 @@ Named list of results.}
 Named list of transformed point values.}
       \item{\code{ys_extra}}{(named \code{list()} | \code{NULL})\cr
 Named list of additional information.}
-      \item{\code{extra}}{(named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{ys_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }

--- a/man/ArchiveAsyncFrozen.Rd
+++ b/man/ArchiveAsyncFrozen.Rd
@@ -174,7 +174,7 @@ The archive to freeze.}
   Push queued points to the archive.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsyncFrozen$push_points(xss, xss_extra = NULL, extra = NULL)}
+    \preformatted{ArchiveAsyncFrozen$push_points(xss, xss_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -184,9 +184,6 @@ The archive to freeze.}
 List of named lists of point values.}
       \item{\code{xss_extra}}{(list of named \code{list()} | \code{NULL})\cr
 List of named lists of additional information.}
-      \item{\code{extra}}{(list of named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{xss_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }
@@ -199,7 +196,7 @@ Use \code{xss_extra} instead.}
   Push a single queued point to the archive.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsyncFrozen$push_point(xs, xs_extra = NULL, extra = NULL)}
+    \preformatted{ArchiveAsyncFrozen$push_point(xs, xs_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -209,9 +206,6 @@ Use \code{xss_extra} instead.}
 Named list of point values.}
       \item{\code{xs_extra}}{(named \code{list()} | \code{NULL})\cr
 Named list of additional information.}
-      \item{\code{extra}}{(named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{xs_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }
@@ -224,7 +218,7 @@ Use \code{xs_extra} instead.}
   Push running points to the archive.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsyncFrozen$push_running_points(xss, xss_extra = NULL, extra = NULL)}
+    \preformatted{ArchiveAsyncFrozen$push_running_points(xss, xss_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -234,9 +228,6 @@ Use \code{xs_extra} instead.}
 List of named lists of point values.}
       \item{\code{xss_extra}}{(list of named \code{list()} | \code{NULL})\cr
 List of named lists of additional information.}
-      \item{\code{extra}}{(list of named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{xss_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }
@@ -249,7 +240,7 @@ Use \code{xss_extra} instead.}
   Push running point to the archive.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsyncFrozen$push_running_point(xs, xs_extra = NULL, extra = NULL)}
+    \preformatted{ArchiveAsyncFrozen$push_running_point(xs, xs_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -259,9 +250,6 @@ Use \code{xss_extra} instead.}
 Named list of point values.}
       \item{\code{xs_extra}}{(named \code{list()} | \code{NULL})\cr
 Named list of additional information.}
-      \item{\code{extra}}{(named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{xs_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }
@@ -398,13 +386,7 @@ If \code{NULL}, a generic error message is used.}
   Save the results of multiple running points and move them to the finished points.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsyncFrozen$finish_points(
-  keys,
-  yss,
-  x_domains,
-  yss_extra = NULL,
-  extra = NULL
-)}
+    \preformatted{ArchiveAsyncFrozen$finish_points(keys, yss, x_domains, yss_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -418,9 +400,6 @@ List of named lists of results.}
 List of named lists of transformed point values.}
       \item{\code{yss_extra}}{(list of named \code{list()} | \code{NULL})\cr
 List of named lists of additional information.}
-      \item{\code{extra}}{(list of named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{yss_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }
@@ -433,13 +412,7 @@ Use \code{yss_extra} instead.}
   Save the results of a running point and move it to the finished points.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
-    \preformatted{ArchiveAsyncFrozen$finish_point(
-  key,
-  ys,
-  x_domain,
-  ys_extra = NULL,
-  extra = NULL
-)}
+    \preformatted{ArchiveAsyncFrozen$finish_point(key, ys, x_domain, ys_extra = NULL)}
     \if{html}{\out{</div>}}
   }
   \subsection{Arguments}{
@@ -453,9 +426,6 @@ Named list of results.}
 Named list of transformed point values.}
       \item{\code{ys_extra}}{(named \code{list()} | \code{NULL})\cr
 Named list of additional information.}
-      \item{\code{extra}}{(named \code{list()} | \code{NULL})\cr
-Deprecated argument for additional information.
-Use \code{ys_extra} instead.}
     }
     \if{html}{\out{</div>}}
   }

--- a/tests/testthat/test_ArchiveAsync.R
+++ b/tests/testthat/test_ArchiveAsync.R
@@ -158,46 +158,6 @@ test_that("push_points works with extras argument", {
   expect_equal(queued$batch_id, c(1, 1))
 })
 
-test_that("extra is a legacy alias for xss_extra / xs_extra", {
-  rush = start_rush_worker()
-  on.exit({
-    rush$reset()
-  })
-
-  archive = ArchiveAsync$new(
-    search_space = PS_2D,
-    codomain = FUN_2D_CODOMAIN,
-    rush = rush
-  )
-
-  # legacy `extra` alias on the batch method
-  archive$push_points(list(list(x1 = 1, x2 = 2)), extra = list(list(extra_info = "legacy")))
-  # canonical `xs_extra` on the single method
-  archive$push_point(list(x1 = 3, x2 = 4), xs_extra = list(extra_info = "canonical"))
-
-  expect_equal(sort(archive$queued_data$extra_info), c("canonical", "legacy"))
-})
-
-test_that("xss_extra takes precedence over the legacy extra argument", {
-  rush = start_rush_worker()
-  on.exit({
-    rush$reset()
-  })
-
-  archive = ArchiveAsync$new(
-    search_space = PS_2D,
-    codomain = FUN_2D_CODOMAIN,
-    rush = rush
-  )
-
-  archive$push_points(
-    list(list(x1 = 1, x2 = 2)),
-    xss_extra = list(list(extra_info = "canonical")),
-    extra = list(list(extra_info = "legacy")))
-
-  expect_equal(archive$queued_data$extra_info, "canonical")
-})
-
 test_that("push_points assigns one timestamp to all points in a batch", {
   rush = start_rush_worker()
   on.exit({
@@ -287,7 +247,7 @@ test_that("push_point works", {
     rush = rush
   )
 
-  key = archive$push_point(list(x1 = 1, x2 = 2), extra = list(extra_info = "point1"))
+  key = archive$push_point(list(x1 = 1, x2 = 2), xs_extra = list(extra_info = "point1"))
   expect_character(key, len = 1)
 
   queued = archive$queued_data
@@ -390,7 +350,7 @@ test_that("finish_point stores extra information", {
     keys,
     ys = list(y1 = 1, y2 = 2),
     x_domain = list(x1 = 1, x2 = 2),
-    extra = list(extra_info = "point1"))
+    ys_extra = list(extra_info = "point1"))
 
   expect_data_table(archive$finished_data, nrows = 1)
   expect_equal(archive$finished_data$extra_info, "point1")


### PR DESCRIPTION
## Summary

Removes the deprecated `extra` argument from `ArchiveAsync`'s `$push_points()`, `$push_point()`, `$push_running_points()`, `$push_running_point()`, `$finish_points()`, and `$finish_point()`, now that `rush` 1.2.0 is released on CRAN. Callers should use the corresponding `xss_extra`, `xs_extra`, or `yss_extra`/`ys_extra` argument instead.

Changes:
- Drop the `extra` parameter and its `%??%` fallback from the six `ArchiveAsync` methods and the matching overrides in `ArchiveAsyncFrozen`.
- Update the still-deprecated `$push_result()` to forward via `ys_extra`.
- Update the internal `OptimInstanceAsync$.eval_point()` caller, which passed `extra =` to `$finish_point()`.
- Bump the required `rush` version to `>= 1.2.0` in `DESCRIPTION`.
- Remove the two tests exercising the legacy `extra` alias and switch other tests to the canonical argument names.

## Verification

```r
devtools::install()
Sys.setenv(RUSH_TEST_USE_REDIS = "true")
devtools::test(filter = "^ArchiveAsync$")
#> [ FAIL 0 | WARN 0 | SKIP 0 | PASS 83 ]
```

Note: the async tests spawn separate `mirai` worker processes, so the package must be installed (not just `load_all`ed) for the workers to see the updated code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)