### PR TITLE
refactor: replace adagio with libcmaesr in OptimizerBatchCmaes

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -24,12 +24,15 @@ cran
 datatable
 deqn
 donttest
+dsigma
 Eggholder
 elmt
 emoa
 evals
+fevals
 Forrester
 fselect
+ftarget
 ftol
 gensa
 Goldstein
@@ -49,6 +52,8 @@ Lacoste
 LBFGS
 Lgls
 LGLSXP
+libcmaes
+libcmaesr
 lightswitch
 lockfiles
 logicals

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,10 +35,10 @@ Imports:
     moocore (>= 0.3.2),
     R6
 Suggests:
-    adagio,
     GenSA,
     irace (>= 4.0.0),
     knitr,
+    libcmaesr,
     mirai,
     nloptr,
     processx,
@@ -49,6 +49,7 @@ Suggests:
     testthat (>= 3.0.0),
     uuid
 Remotes:
+    mlr-org/libcmaesr,
     mlr-org/rush
 Config/testthat/edition: 3
 Config/testthat/parallel: false

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,6 @@ Suggests:
     testthat (>= 3.0.0),
     uuid
 Remotes:
-    mlr-org/libcmaesr,
     mlr-org/rush
 Config/testthat/edition: 3
 Config/testthat/parallel: false

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bbotk (development version)
 
+* refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimizerBatchCmaes.R
+++ b/R/OptimizerBatchCmaes.R
@@ -8,7 +8,6 @@
 #' Calls [libcmaesr::cmaes()] from package \CRANpkg{libcmaesr}, which is a lightweight interface to the `libcmaes` C++
 #' library.
 #' The algorithm is typically applied to search space dimensions between three and fifty.
-#' Lower search space dimensions might crash.
 #'
 #' @templateVar id cmaes
 #' @template section_dictionary_optimizers
@@ -141,13 +140,6 @@ OptimizerBatchCmaes = R6Class(
       }
       pv$start_values = NULL
       pv$start = NULL
-
-      if (length(x0) < 2L) {
-        warning(
-          "CMA-ES is typically applied to search space dimensions between three and fifty.",
-          " A lower search space dimension might crash."
-        )
-      }
 
       # the terminators control the budget, so the internal evaluation limit is disabled and `ftarget` is reserved for
       # stopping the algorithm from within the objective function

--- a/R/OptimizerBatchCmaes.R
+++ b/R/OptimizerBatchCmaes.R
@@ -152,8 +152,9 @@ OptimizerBatchCmaes = R6Class(
       # condition is stored here and re-raised below
       condition = NULL
       fun = function(x) {
-        # signaling the termination with an exception would unwind the C++ stack of libcmaes, so the generation is
-        # left unevaluated and the target value is reported instead, which stops the algorithm after this generation
+        # `eval_batch()` signals the termination with an exception, which libcmaesr prints to stderr, so the
+        # generation is left unevaluated and the target value is reported instead, which stops the algorithm after
+        # this generation without any output
         if (inst$is_terminated) {
           return(rep(-Inf, nrow(x)))
         }

--- a/R/OptimizerBatchCmaes.R
+++ b/R/OptimizerBatchCmaes.R
@@ -4,35 +4,46 @@
 #' @name mlr_optimizers_cmaes
 #'
 #' @description
-#' `OptimizerBatchCmaes` class that implements CMA-ES. Calls [adagio::pureCMAES()]
-#' from package \CRANpkg{adagio}. The algorithm is typically applied to search
-#' space dimensions between three and fifty. Lower search space dimensions might
-#' crash.
+#' `OptimizerBatchCmaes` class that implements CMA-ES.
+#' Calls [libcmaesr::cmaes()] from package \CRANpkg{libcmaesr}, which is a lightweight interface to the `libcmaes` C++
+#' library.
+#' The algorithm is typically applied to search space dimensions between three and fifty.
+#' Lower search space dimensions might crash.
 #'
 #' @templateVar id cmaes
 #' @template section_dictionary_optimizers
 #'
 #' @section Parameters:
 #' \describe{
-#' \item{`sigma`}{`numeric(1)`}
 #' \item{`start_values`}{`character(1)`\cr
 #' Create `"random"` start values or based on `"center"` of search space?
 #' In the latter case, it is the center of the parameters before a trafo is applied.
 #' If set to `"custom"`, the start values can be passed via the `start` parameter.}
 #' \item{`start`}{`numeric()`\cr
 #' Custom start values. Only applicable if `start_values` parameter is set to `"custom"`.}
+#' \item{`seed`}{`integer(1)`\cr
+#' Seed of the random number generator of `libcmaes`.
+#' Unset by default, in which case the generator is seeded from R and the optimization is reproducible with
+#' [set.seed()].}
 #' }
 #'
-#' For the meaning of the control parameters, see [adagio::pureCMAES()]. Note
-#' that we have removed all control parameters which refer to the termination of
-#' the algorithm and where our terminators allow to obtain the same behavior.
+#' All remaining parameters are passed to [libcmaesr::cmaes_control()], see there for their meaning.
+#' Note that we have removed all control parameters which refer to the termination of the algorithm and where our
+#' terminators allow to obtain the same behavior, i.e. `max_fevals`, `max_iter`, and `ftarget`.
+#' The internal convergence criteria of the algorithm still apply, so the optimization can stop before the
+#' [Terminator] is triggered.
+#'
+#' @section Batch evaluation:
+#' The optimizer evaluates a whole generation of `lambda` points in one batch.
+#' The [Terminator] is only checked between generations, so the number of evaluations can exceed the budget of
+#' [TerminatorEvals] by up to `lambda - 1` points.
 #'
 #' @template section_progress_bars
 #'
 #' @export
 #' @examples
-#' # example only runs if GenSA is available
-#' if (mlr3misc::require_namespaces("adagio", quietly = TRUE)) {
+#' # example only runs if libcmaesr is available
+#' if (mlr3misc::require_namespaces("libcmaesr", quietly = TRUE)) {
 #' # define the objective function
 #' fun = function(xs) {
 #'   list(y = - (xs[[1]] - 2)^2 - (xs[[2]] + 3)^2 - (xs[[3]] + 4)^2 + 10)
@@ -84,19 +95,35 @@ OptimizerBatchCmaes = R6Class(
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function() {
       param_set = ps(
-        sigma = p_dbl(default = 0.5),
-        start_values = p_fct(default = "random", levels = c("random", "center", "custom")),
+        algo = p_fct(
+          default = "acmaes",
+          levels = c(
+            "cmaes", "ipop", "bipop", "acmaes", "aipop", "abipop", "sepcmaes", "sepipop", "sepbipop", "sepacmaes",
+            "sepaipop", "sepabipop", "vdcma", "vdipopcma", "vdbipopcma"
+          )
+        ),
+        sigma = p_dbl(lower = 0),
+        lambda = p_int(lower = 2L),
+        max_restarts = p_int(lower = 0L),
+        elitism = p_int(lower = 0L, upper = 3L),
+        tpa = p_int(lower = 0L, upper = 2L),
+        tpa_dsigma = p_dbl(lower = 0),
+        seed = p_int(lower = 0L),
+        f_tolerance = p_dbl(lower = 0),
+        x_tolerance = p_dbl(lower = 0),
+        x0_lower = p_uty(default = NULL),
+        x0_upper = p_uty(default = NULL),
+        # bbotk parameters
+        start_values = p_fct(levels = c("random", "center", "custom"), init = "random"),
         start = p_uty(default = NULL, depends = start_values == "custom")
       )
-      param_set$values$start_values = "random"
-      param_set$values$start = NULL
 
       super$initialize(
         id = "cmaes",
         param_set = param_set,
         param_classes = "ParamDbl",
         properties = "single-crit",
-        packages = "adagio",
+        packages = "libcmaesr",
         label = "Covariance Matrix Adaptation Evolution Strategy",
         man = "bbotk::mlr_optimizers_cmaes"
       )
@@ -107,32 +134,61 @@ OptimizerBatchCmaes = R6Class(
     .optimize = function(inst) {
       pv = self$param_set$values
 
-      if (pv$start_values == "custom") {
-        pv$par = pv$start
-        pv$start_values = NULL
-        pv$start = NULL
+      x0 = if (pv$start_values == "custom") {
+        assert_numeric(pv$start, len = inst$search_space$length, any.missing = FALSE)
       } else {
-        pv$par = search_start(inst$search_space, type = pv$start_values)
-        pv$start_values = NULL
-        pv$start = NULL
+        search_start(inst$search_space, type = pv$start_values)
       }
+      pv$start_values = NULL
+      pv$start = NULL
 
-      pv$stopeval = .Machine$integer.max # make sure pureCMAES does not stop
-      pv$stopfitness = -Inf
-
-      if (length(pv$par) < 2L) {
+      if (length(x0) < 2L) {
         warning(
           "CMA-ES is typically applied to search space dimensions between three and fifty.",
           " A lower search space dimension might crash."
         )
       }
 
-      invoke(
-        adagio::pureCMAES,
-        fun = inst$objective_function,
-        lower = inst$search_space$lower,
-        upper = inst$search_space$upper,
-        .args = pv
+      # the terminators control the budget, so the internal evaluation limit is disabled and `ftarget` is reserved for
+      # stopping the algorithm from within the objective function
+      control = invoke(libcmaesr::cmaes_control, max_fevals = NA_integer_, ftarget = -Inf, .args = pv)
+
+      target = inst$objective$codomain$target_ids
+      direction = inst$objective_multiplicator
+
+      # libcmaesr catches errors raised in the objective function and re-raises a generic error, so the original
+      # condition is stored here and re-raised below
+      condition = NULL
+      fun = function(x) {
+        # signaling the termination with an exception would unwind the C++ stack of libcmaes, so the generation is
+        # left unevaluated and the target value is reported instead, which stops the algorithm after this generation
+        if (inst$is_terminated) {
+          return(rep(-Inf, nrow(x)))
+        }
+        tryCatch(
+          {
+            xdt = set_names(as.data.table(x), inst$search_space$ids())
+            inst$eval_batch(xdt)[[target]] * direction
+          },
+          error = function(cond) {
+            condition <<- cond
+            stop(cond)
+          }
+        )
+      }
+
+      tryCatch(
+        libcmaesr::cmaes(
+          objective = fun,
+          x0 = unname(x0),
+          lower = inst$search_space$lower,
+          upper = inst$search_space$upper,
+          control = control,
+          batch = TRUE
+        ),
+        error = function(cond) {
+          stop(condition %??% cond)
+        }
       )
     }
   )

--- a/R/OptimizerBatchCmaes.R
+++ b/R/OptimizerBatchCmaes.R
@@ -141,23 +141,16 @@ OptimizerBatchCmaes = R6Class(
       pv$start_values = NULL
       pv$start = NULL
 
-      # the terminators control the budget, so the internal evaluation limit is disabled and `ftarget` is reserved for
-      # stopping the algorithm from within the objective function
-      control = invoke(libcmaesr::cmaes_control, max_fevals = NA_integer_, ftarget = -Inf, .args = pv)
+      # the terminators control the budget, so the internal evaluation limit is disabled
+      control = invoke(libcmaesr::cmaes_control, max_fevals = NA_integer_, .args = pv)
 
       target = inst$objective$codomain$target_ids
       direction = inst$objective_multiplicator
 
-      # libcmaesr catches errors raised in the objective function and re-raises a generic error, so the original
+      # libcmaesr catches the condition signaled by `eval_batch()` and re-raises a generic error, so the original
       # condition is stored here and re-raised below
       condition = NULL
       fun = function(x) {
-        # `eval_batch()` signals the termination with an exception, which libcmaesr prints to stderr, so the
-        # generation is left unevaluated and the target value is reported instead, which stops the algorithm after
-        # this generation without any output
-        if (inst$is_terminated) {
-          return(rep(-Inf, nrow(x)))
-        }
         tryCatch(
           {
             xdt = set_names(as.data.table(x), inst$search_space$ids())

--- a/man/mlr_optimizers_cmaes.Rd
+++ b/man/mlr_optimizers_cmaes.Rd
@@ -5,10 +5,11 @@
 \alias{OptimizerBatchCmaes}
 \title{Optimization via Covariance Matrix Adaptation Evolution Strategy}
 \description{
-\code{OptimizerBatchCmaes} class that implements CMA-ES. Calls \code{\link[adagio:pureCMAES]{adagio::pureCMAES()}}
-from package \CRANpkg{adagio}. The algorithm is typically applied to search
-space dimensions between three and fifty. Lower search space dimensions might
-crash.
+\code{OptimizerBatchCmaes} class that implements CMA-ES.
+Calls \code{\link[libcmaesr:cmaes]{libcmaesr::cmaes()}} from package \CRANpkg{libcmaesr}, which is a lightweight interface to the \code{libcmaes} C++
+library.
+The algorithm is typically applied to search space dimensions between three and fifty.
+Lower search space dimensions might crash.
 }
 \section{Dictionary}{
 
@@ -23,18 +24,30 @@ opt("cmaes")
 \section{Parameters}{
 
 \describe{
-\item{\code{sigma}}{\code{numeric(1)}}
 \item{\code{start_values}}{\code{character(1)}\cr
 Create \code{"random"} start values or based on \code{"center"} of search space?
 In the latter case, it is the center of the parameters before a trafo is applied.
 If set to \code{"custom"}, the start values can be passed via the \code{start} parameter.}
 \item{\code{start}}{\code{numeric()}\cr
 Custom start values. Only applicable if \code{start_values} parameter is set to \code{"custom"}.}
+\item{\code{seed}}{\code{integer(1)}\cr
+Seed of the random number generator of \code{libcmaes}.
+Unset by default, in which case the generator is seeded from R and the optimization is reproducible with
+\code{\link[=set.seed]{set.seed()}}.}
 }
 
-For the meaning of the control parameters, see \code{\link[adagio:pureCMAES]{adagio::pureCMAES()}}. Note
-that we have removed all control parameters which refer to the termination of
-the algorithm and where our terminators allow to obtain the same behavior.
+All remaining parameters are passed to \code{\link[libcmaesr:cmaes_control]{libcmaesr::cmaes_control()}}, see there for their meaning.
+Note that we have removed all control parameters which refer to the termination of the algorithm and where our
+terminators allow to obtain the same behavior, i.e. \code{max_fevals}, \code{max_iter}, and \code{ftarget}.
+The internal convergence criteria of the algorithm still apply, so the optimization can stop before the
+\link{Terminator} is triggered.
+}
+
+\section{Batch evaluation}{
+
+The optimizer evaluates a whole generation of \code{lambda} points in one batch.
+The \link{Terminator} is only checked between generations, so the number of evaluations can exceed the budget of
+\link{TerminatorEvals} by up to \code{lambda - 1} points.
 }
 
 \section{Progress Bars}{
@@ -46,8 +59,8 @@ combined with a \link{Terminator}. Simply wrap the function in
 }
 
 \examples{
-# example only runs if GenSA is available
-if (mlr3misc::require_namespaces("adagio", quietly = TRUE)) {
+# example only runs if libcmaesr is available
+if (mlr3misc::require_namespaces("libcmaesr", quietly = TRUE)) {
 # define the objective function
 fun = function(xs) {
   list(y = - (xs[[1]] - 2)^2 - (xs[[2]] + 3)^2 - (xs[[3]] + 4)^2 + 10)

--- a/man/mlr_optimizers_cmaes.Rd
+++ b/man/mlr_optimizers_cmaes.Rd
@@ -9,7 +9,6 @@
 Calls \code{\link[libcmaesr:cmaes]{libcmaesr::cmaes()}} from package \CRANpkg{libcmaesr}, which is a lightweight interface to the \code{libcmaes} C++
 library.
 The algorithm is typically applied to search space dimensions between three and fifty.
-Lower search space dimensions might crash.
 }
 \section{Dictionary}{
 

--- a/tests/testthat/_snaps/OptimizerBatchCmaes.md
+++ b/tests/testthat/_snaps/OptimizerBatchCmaes.md
@@ -5,8 +5,8 @@
     Output
       
       -- <OptimizerBatchCmaes> - Covariance Matrix Adaptation Evolution Strategy -----
-      * Parameters: start_values=random
+      * Parameters: lambda=5, start_values=random
       * Parameter classes: <ParamDbl>
       * Properties: single-crit
-      * Packages: bbotk and adagio
+      * Packages: bbotk and libcmaesr
 

--- a/tests/testthat/test_OptimizerBatchCmaes.R
+++ b/tests/testthat/test_OptimizerBatchCmaes.R
@@ -1,5 +1,5 @@
 test_that("OptimizerBatchCmaes", {
-  skip_if_not_installed("adagio")
+  skip_if_not_installed("libcmaesr")
 
   search_space = domain = ps(
     x1 = p_dbl(-10, 10),
@@ -24,9 +24,11 @@ test_that("OptimizerBatchCmaes", {
     terminator = trm("evals", n_evals = 10L)
   )
 
-  z = test_optimizer(instance, "cmaes", real_evals = 10L)
+  z = test_optimizer(instance, "cmaes", lambda = 5L, real_evals = 10L)
 
   expect_class(z$optimizer, "OptimizerBatchCmaes")
+  # one batch per generation
+  expect_equal(instance$archive$n_batch, 2L)
   expect_snapshot(z$optimizer)
 
   expect_error(test_optimizer_2d("cmaes", term_evals = 10L), "multi-crit objectives")
@@ -35,4 +37,37 @@ test_that("OptimizerBatchCmaes", {
   optimizer = opt("cmaes", start_values = "custom", start = c(-9.1, 1.3))
   optimizer$optimize(instance)
   # start values are used for the initial mean vector so a deterministic test is not applicable
+  expect_data_table(instance$archive$data, min.rows = 10L)
+})
+
+test_that("OptimizerBatchCmaes finds the optimum", {
+  skip_if_not_installed("libcmaesr")
+
+  instance = OptimInstanceBatchSingleCrit$new(
+    objective = OBJ_2D,
+    search_space = PS_2D,
+    terminator = trm("evals", n_evals = 200L)
+  )
+
+  set.seed(1)
+  opt("cmaes")$optimize(instance)
+  expect_equal(unname(instance$result_y), 0, tolerance = 1e-4)
+})
+
+test_that("OptimizerBatchCmaes propagates errors of the objective function", {
+  skip_if_not_installed("libcmaesr")
+
+  objective = ObjectiveRFun$new(
+    fun = function(xs) stop("objective failed"),
+    domain = PS_2D,
+    properties = "single-crit"
+  )
+
+  instance = OptimInstanceBatchSingleCrit$new(
+    objective = objective,
+    search_space = PS_2D,
+    terminator = trm("evals", n_evals = 10L)
+  )
+
+  expect_error(opt("cmaes")$optimize(instance), "objective failed")
 })


### PR DESCRIPTION
`OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`. `adagio` is dropped from `Suggests`, `libcmaesr` is added, and `mlr-org/libcmaesr` is added to `Remotes` until it is on CRAN.

## Parameters

`libcmaesr` exposes far more of CMA-ES than `adagio` did, so the optimizer gains `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper`. The `algo` parameter selects the active, separable, and VD variants as well as the IPOP and BIPOP restart strategies, defaulting to `"acmaes"`.

Following the existing convention, the control parameters that our terminators cover are removed, i.e. `max_fevals`, `max_iter`, and `ftarget`. `sigma` no longer defaults to `0.5` but is handled by `libcmaes`. `start_values` and `start` are unchanged.

By default `seed` is unset, in which case `libcmaesr` seeds its generator from R, so a run is reproducible with `set.seed()`.

The warning about crashing in low dimensions was specific to `adagio::pureCMAES()` and is removed. All 15 variants optimize one-dimensional search spaces reliably.

## Batch evaluation

The optimizer uses `batch = TRUE` and evaluates a whole generation of `lambda` points in one `$eval_batch()` call, so one archive batch corresponds to one generation. The terminator is checked between generations, which means the number of evaluations can exceed the budget of `TerminatorEvals` by up to `lambda - 1` points.

## Termination

`libcmaesr` catches errors raised in the objective function and re-raises a generic error, so the `Mlr3ErrorBbotkTerminated` condition signaled by `$eval_batch()` would not reach the base class. The original condition is therefore stored and re-raised after `cmaes()` returns. This also means genuine errors of the objective function keep their own condition instead of being masked by `libcmaesr`'s generic message.

## Needs a fix in `libcmaesr`

`src/rc_helpers.c:88` uses `R_tryEval()`, which prints the caught condition to stderr. Every optimization therefore ends with a spurious

```
Error:
✖ Objective (obj:function, term:TerminatorEvals) terminated
→ Class: Mlr3ErrorBbotkTerminated
```

even though the run succeeded. `R_tryEvalSilent()` would avoid this and let callers decide how to report errors raised in the objective function. This should be fixed in `libcmaesr` before this PR is merged.

## Testing

`devtools::test()` passes except for `test_TerminatorRunTime.R:10` and `test_OptimizerAsync.R:114`, which fail the same way on `main` in this environment (timing related).

🤖 Generated with [Claude Code](https://claude.com/claude-code)