### PR TITLE
fix: honor internal termination parameters in nloptr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `OptimizerBatchNLoptr` no longer overwrites the `maxeval`, `maxtime`, and `stopval` parameters. The internal termination criteria set by the user are now passed on to `nloptr::nloptr()` (#361).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimizerBatchNLoptr.R
+++ b/R/OptimizerBatchNLoptr.R
@@ -49,7 +49,7 @@
 #'   Relative tolerance.
 #'   Original default is 10^-4.
 #'   Deactivate with `-1`.
-#'   Overwritten with `-1`.}
+#'   Default is `-1`.}
 #' \item{`xtol_abs`}{`numeric(1)`\cr
 #'   Absolute tolerance.
 #'   Deactivate with `-1`.
@@ -211,16 +211,9 @@ OptimizerBatchNLoptr = R6Class(
       }
       pv$eval_grad_f = eval_grad_f
 
+      # the internal termination criteria are deactivated by their init values and are only passed on when the user
+      # sets them
       opts = pv[which(names(pv) %nin% formalArgs(nloptr::nloptr))]
-      # deactivate termination criterions which are replaced by Terminators
-      opts = insert_named(
-        opts,
-        list(
-          maxeval = -1,
-          maxtime = -1,
-          stopval = -Inf
-        )
-      )
       pv = pv[which(names(pv) %nin% names(opts))]
 
       invoke(

--- a/man/mlr_optimizers_nloptr.Rd
+++ b/man/mlr_optimizers_nloptr.Rd
@@ -58,7 +58,7 @@ Default is \code{-1L}.}
 Relative tolerance.
 Original default is 10^-4.
 Deactivate with \code{-1}.
-Overwritten with \code{-1}.}
+Default is \code{-1}.}
 \item{\code{xtol_abs}}{\code{numeric(1)}\cr
 Absolute tolerance.
 Deactivate with \code{-1}.

--- a/tests/testthat/test_OptimizerBatchNLoptr.R
+++ b/tests/testthat/test_OptimizerBatchNLoptr.R
@@ -59,3 +59,19 @@ test_that("OptimizerBatchNLoptr custom start values work", {
   optimizer$optimize(instance)
   expect_equal(unlist(instance$archive$data[1L, c("x1", "x2")]), c(x1 = -9.1, x2 = 1.3))
 })
+
+test_that("OptimizerBatchNLoptr internal termination criteria are honored", {
+  skip_on_os("windows")
+  skip_if_not_installed("nloptr")
+
+  instance = oi(OBJ_1D, search_space = PS_1D, terminator = trm("evals", n_evals = 50L))
+  optimizer = opt("nloptr", algorithm = "NLOPT_LN_BOBYQA", x0 = 0.9, maxeval = 5L)
+  optimizer$optimize(instance)
+  # nloptr stops on its own budget, the terminator would allow 50 evaluations
+  expect_lte(instance$archive$n_evals, 10L)
+
+  instance = oi(OBJ_1D, search_space = PS_1D, terminator = trm("evals", n_evals = 50L))
+  optimizer = opt("nloptr", algorithm = "NLOPT_LN_BOBYQA", x0 = 0.9)
+  optimizer$optimize(instance)
+  expect_gt(instance$archive$n_evals, 10L)
+})


### PR DESCRIPTION
## Problem

`OptimizerBatchNLoptr` documents `stopval`, `maxtime`, and `maxeval` under *Internal Termination Parameters* as criteria that "can be used", but `.optimize()` overwrote all three unconditionally:

```r
opts = insert_named(opts, list(maxeval = -1, maxtime = -1, stopval = -Inf))
```

`opt("nloptr", algorithm = "NLOPT_LN_BOBYQA", maxeval = 5L)` with `trm("evals", n_evals = 50)` ran the full 50 evaluations.

## Fix

The three parameters already carry their deactivated values as `init` (`-1L`, `-1L`, `-Inf`), so the terminator stays in charge by default without overwriting anything.
Dropping the `insert_named()` call makes user-set values effective.

Also fixes the `xtol_rel` documentation, which claimed the value is "overwritten with `-1`" when `-1` is just its default.

## Tests

New regression test: `maxeval = 5L` stops early where the terminator would allow 50 evaluations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)