### PR TITLE
fix: pass digits to irace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `OptimizerBatchIrace` now passes the `digits` parameter to irace instead of always using 15 digits (#362).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimizerBatchIrace.R
+++ b/R/OptimizerBatchIrace.R
@@ -211,7 +211,7 @@ OptimizerBatchIrace = R6Class(
       pv$digits = NULL
 
       scenario = list(
-        parameters = paradox_to_irace(inst$search_space, pv$digits),
+        parameters = paradox_to_irace(inst$search_space, digits),
         maxExperiments = terminator$param_set$values$n_evals,
         targetRunnerData = list(inst = inst)
       )
@@ -293,8 +293,7 @@ target_runner_default = function(experiment, exec_target_runner, scenario, targe
 
 paradox_to_irace = function(param_set, digits) {
   assertClass(param_set, "ParamSet")
-  # workaround for mlr3tuning 0.15.0
-  digits = assert_int(digits %??% 15, lower = 0)
+  digits = assert_int(digits, lower = 0)
   if ("ParamUty" %in% param_set$class) {
     stop("<ParamUty> not supported by <OptimizerBatchIrace>")
   }

--- a/tests/testthat/test_OptimizerBatchIrace.R
+++ b/tests/testthat/test_OptimizerBatchIrace.R
@@ -325,3 +325,31 @@ test_that("paradox_to_irace works with parameters with multiple dependencies", {
     hierarchy = c(1, 1, 1, 1, 2, 2, 2, 2)
   )
 })
+
+test_that("OptimizerBatchIrace digits are passed to irace", {
+  skip_if_not_installed("irace")
+
+  search_space = domain = ps(
+    x1 = p_dbl(-5, 10),
+    x2 = p_dbl(0, 15)
+  )
+
+  fun = function(xdt, instances) {
+    data.table(y = branin(xdt[["x1"]], xdt[["x2"]], noise = as.numeric(instances)))
+  }
+
+  objective = ObjectiveRFunDt$new(fun = fun, domain = domain)
+
+  instance = OptimInstanceBatchSingleCrit$new(
+    objective = objective,
+    search_space = search_space,
+    terminator = trm("evals", n_evals = 96)
+  )
+
+  optimizer = opt("irace", instances = rnorm(10, mean = 0, sd = 0.1), digits = 2L)
+  x = capture.output(optimizer$optimize(instance))
+
+  archive = instance$archive$data
+  expect_equal(archive$x1, round(archive$x1, 2L))
+  expect_equal(archive$x2, round(archive$x2, 2L))
+})


### PR DESCRIPTION
## Problem

```r
digits = pv$digits
pv$digits = NULL

scenario = list(
  parameters = paradox_to_irace(inst$search_space, pv$digits),  # already NULL
  ...
)
```

The local `digits` was dead and `paradox_to_irace()` received `NULL`, where `digits %??% 15` silently substituted 15.
`opt("irace", digits = 2L)` produced values like `x1 = 1.69054552912712`.

## Fix

Pass the local `digits`, and drop the `%??% 15` fallback in `paradox_to_irace()`.
The fallback was commented as a workaround for mlr3tuning 0.15.0; `digits` is a `"required"` parameter with `init = 15`, so it is always set.

## Tests

New regression test: `digits = 2L` rounds every sampled value in the archive to two decimals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)