### PR TITLE
fix: compute irace archive step column from the instance column

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `OptimizerBatchIrace` now writes the actual step of a race into the `step` column of the archive, which was always `1` (#363).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimizerBatchIrace.R
+++ b/R/OptimizerBatchIrace.R
@@ -223,7 +223,7 @@ OptimizerBatchIrace = R6Class(
       # add race and step to archive
       iraceResults = irace::read_logfile(self$param_set$values$logFile) # nolint
       log = iraceResults$state$experiment_log
-      log[, "step" := rleid("instance"), by = "iteration"]
+      log[, "step" := rleid(get("instance")), by = "iteration"]
       set(inst$archive$data, j = "race", value = log$iteration)
       set(inst$archive$data, j = "step", value = log$step)
       setcolorder(

--- a/tests/testthat/test_OptimizerBatchIrace.R
+++ b/tests/testthat/test_OptimizerBatchIrace.R
@@ -325,3 +325,32 @@ test_that("paradox_to_irace works with parameters with multiple dependencies", {
     hierarchy = c(1, 1, 1, 1, 2, 2, 2, 2)
   )
 })
+
+test_that("OptimizerBatchIrace archive step column counts the steps of a race", {
+  skip_if_not_installed("irace")
+
+  search_space = domain = ps(
+    x1 = p_dbl(-5, 10),
+    x2 = p_dbl(0, 15)
+  )
+
+  fun = function(xdt, instances) {
+    data.table(y = branin(xdt[["x1"]], xdt[["x2"]], noise = as.numeric(instances)))
+  }
+
+  objective = ObjectiveRFunDt$new(fun = fun, domain = domain)
+
+  instance = OptimInstanceBatchSingleCrit$new(
+    objective = objective,
+    search_space = search_space,
+    terminator = trm("evals", n_evals = 96)
+  )
+
+  optimizer = opt("irace", instances = rnorm(10, mean = 0, sd = 0.1))
+  x = capture.output(optimizer$optimize(instance))
+
+  archive = instance$archive$data
+  expect_gt(uniqueN(archive$step), 1L)
+  # one step of a race evaluates the surviving configurations on one instance
+  expect_true(all(archive[, uniqueN(get("instance")), by = c("race", "step")]$V1 == 1L))
+})


### PR DESCRIPTION
## Problem

```r
log[, "step" := rleid("instance"), by = "iteration"]
```

`rleid("instance")` takes the run-length id of the literal string, not of the `instance` column, so `step` was `1` for every row of the archive.

## Fix

`rleid(get("instance"))`.

## Tests

The existing test only checked that the column exists (`expect_subset(c("race", "step", ...), names(archive))`).
New regression test: `step` takes more than one value, and every `(race, step)` group covers exactly one instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)