### PR TITLE
fix: reject partial length minimize in nds_selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `nds_selection()` now only accepts a `minimize` argument of length 1 or of the number of objectives, and rejects points with missing values (#365).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/nds_selection.R
+++ b/R/nds_selection.R
@@ -14,7 +14,7 @@
 #' @template param_ref_point
 #' @param minimize ('logical()')\cr
 #'  Should the ranking be based on minimization?
-#'  Can be specified for each dimension or for all.
+#'  Must be of length 1 for all dimensions or of length `nrow(points)` for each dimension.
 #'  Default is `TRUE` for each dimension.
 #'
 #' @return Vector of indices of selected points
@@ -22,16 +22,12 @@
 #' @export
 nds_selection = function(points, n_select, ref_point = NULL, minimize = TRUE) {
   # check input for correctness
-  assert_matrix(points, mode = "numeric")
+  assert_matrix(points, mode = "numeric", any.missing = FALSE)
   assert_int(n_select, lower = 1, upper = ncol(points))
-  assert_logical(
-    minimize,
-    min.len = 1,
-    max.len = nrow(points),
-    any.missing = FALSE
-  )
+  assert_logical(minimize, any.missing = FALSE, min.len = 1)
+  if (length(minimize) == 1L) minimize = rep(minimize, nrow(points))
+  assert_logical(minimize, len = nrow(points), .var.name = "minimize")
   assert_numeric(ref_point, len = nrow(points), null.ok = TRUE)
-  assert_logical(minimize)
 
   # maximize/minimize preprocessing: switch sign in each dim to minimize
   points = points * (minimize * 2 - 1)

--- a/man/nds_selection.Rd
+++ b/man/nds_selection.Rd
@@ -18,7 +18,7 @@ Reference point for hypervolume.}
 
 \item{minimize}{('logical()')\cr
 Should the ranking be based on minimization?
-Can be specified for each dimension or for all.
+Must be of length 1 for all dimensions or of length \code{nrow(points)} for each dimension.
 Default is \code{TRUE} for each dimension.}
 }
 \value{

--- a/tests/testthat/test_nds_selection.R
+++ b/tests/testthat/test_nds_selection.R
@@ -154,3 +154,20 @@ test_that("nds_selection in Archive works", {
     })))
   })
 })
+
+test_that("nds_selection checks the length of minimize", {
+  points = matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9), nrow = 3L)
+
+  expect_error(
+    nds_selection(points, n_select = 1L, minimize = c(TRUE, FALSE)),
+    "minimize"
+  )
+  expect_silent(nds_selection(points, n_select = 1L, minimize = c(TRUE, FALSE, TRUE)))
+  expect_silent(nds_selection(points, n_select = 1L, minimize = TRUE))
+})
+
+test_that("nds_selection rejects missing values", {
+  points = matrix(c(1, 2, NA, 4), nrow = 2L)
+
+  expect_error(nds_selection(points, n_select = 1L), "missing values")
+})


### PR DESCRIPTION
## Problem

```r
assert_logical(minimize, min.len = 1, max.len = nrow(points), any.missing = FALSE)
...
points = points * (minimize * 2 - 1)
```

`minimize = c(TRUE, FALSE)` was accepted for a matrix with three or four objectives.
R then recycled the vector through the matrix in column-major order, flipping the signs of arbitrary *cells* rather than of whole objectives, with no warning and a plausible-looking result.

Separately, a points matrix containing `NA` returned index 1 silently.

## Fix

* `minimize` is recycled explicitly when it is of length 1, and must otherwise be of length `nrow(points)`.
* `assert_matrix(points, any.missing = FALSE)`.
* Drops the duplicated bare `assert_logical(minimize)` call.

## Tests

New regression tests for a partial-length `minimize` (error), the two accepted lengths (silent), and a matrix containing `NA` (error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)