### PR TITLE
fix: check length of xss_trafoed in add_evals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `ArchiveBatch$add_evals()` now checks that `xss_trafoed` has one element per row of `xdt`, which silently corrupted the `x_domain` column before (#366).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/ArchiveBatch.R
+++ b/R/ArchiveBatch.R
@@ -101,7 +101,7 @@ ArchiveBatch = R6Class(
     add_evals = function(xdt, xss_trafoed = NULL, ydt) {
       assert_data_table(xdt)
       assert_data_table(ydt)
-      assert_list(xss_trafoed, null.ok = TRUE)
+      assert_list(xss_trafoed, len = nrow(xdt), null.ok = TRUE)
       assert_data_table(ydt[, self$cols_y, with = FALSE], any.missing = FALSE)
       if (self$check_values) {
         self$search_space$assert_dt(xdt[, self$cols_x, with = FALSE])

--- a/tests/testthat/test_ArchiveBatch.R
+++ b/tests/testthat/test_ArchiveBatch.R
@@ -28,7 +28,7 @@ test_that("Archive", {
 test_that("Archive best works", {
   a = ArchiveBatch$new(PS_2D, FUN_2D_CODOMAIN)
   xdt = data.table(x1 = c(0, 0.5), x2 = c(1, 1))
-  xss_trafoed = list(list(x1 = c(0, 0.5), x2 = c(1, 1)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y = c(1, 0.25))
   a$add_evals(xdt, xss_trafoed, ydt)
   expect_equal(a$best()$y, 0.25)
@@ -97,13 +97,13 @@ test_that("start_time is set by Optimizer", {
 test_that("check_values flag works", {
   a = ArchiveBatch$new(PS_2D, FUN_2D_CODOMAIN, check_values = FALSE)
   xdt = data.table(x1 = c(0, 2), x2 = c(1, 1))
-  xss_trafoed = list(list(x1 = c(0, 0.5), x2 = c(1, 1)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y = c(1, 0.25))
   a$add_evals(xdt, xss_trafoed, ydt)
 
   a = ArchiveBatch$new(PS_2D, FUN_2D_CODOMAIN, check_values = TRUE)
   xdt = data.table(x1 = c(0, 2), x2 = c(1, 1))
-  xss_trafoed = list(list(x1 = c(0, 0.5), x2 = c(1, 1)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y = c(1, 0.25))
   expect_error(a$add_evals(xdt, xss_trafoed, ydt), "x1: Element 1 is not <= 1.", fixed = TRUE)
 })
@@ -135,7 +135,7 @@ test_that("best method works with maximization", {
 
   archive = ArchiveBatch$new(PS_2D, FUN_2D_CODOMAIN)
   xdt = data.table(x1 = runif(5), x2 = runif(5))
-  xss_trafoed = list(list(x1 = runif(5), x2 = runif(5)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y = c(1, 0.25, 2, 0.5, 0.3))
   archive$add_evals(xdt, xss_trafoed, ydt)
 
@@ -156,7 +156,7 @@ test_that("best method works with minimization", {
 
   archive = ArchiveBatch$new(PS_2D, FUN_2D_CODOMAIN)
   xdt = data.table(x1 = runif(5), x2 = runif(5))
-  xss_trafoed = list(list(x1 = runif(5), x2 = runif(5)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y = c(1, 0.25, 2, 0.5, 0.3))
   archive$add_evals(xdt, xss_trafoed, ydt)
 
@@ -177,7 +177,7 @@ test_that("best method returns top n results with maximization", {
 
   archive = ArchiveBatch$new(PS_2D, FUN_2D_CODOMAIN)
   xdt = data.table(x1 = runif(5), x2 = runif(5))
-  xss_trafoed = list(list(x1 = runif(5), x2 = runif(5)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y = c(1, 0.25, 2, 0.5, 0.3))
   archive$add_evals(xdt, xss_trafoed, ydt)
 
@@ -198,7 +198,7 @@ test_that("best method returns top n results with maximization and ties", {
 
   archive = ArchiveBatch$new(PS_2D, FUN_2D_CODOMAIN)
   xdt = data.table(x1 = runif(5), x2 = runif(5))
-  xss_trafoed = list(list(x1 = runif(5), x2 = runif(5)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y = c(1, 1, 2, 0.5, 0.5))
   archive$add_evals(xdt, xss_trafoed, ydt)
 
@@ -219,7 +219,7 @@ test_that("best method returns top n results with minimization", {
 
   archive = ArchiveBatch$new(PS_2D, FUN_2D_CODOMAIN)
   xdt = data.table(x1 = runif(5), x2 = runif(5))
-  xss_trafoed = list(list(x1 = runif(5), x2 = runif(5)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y = c(1, 0.25, 2, 0.5, 0.3))
   archive$add_evals(xdt, xss_trafoed, ydt)
 
@@ -240,7 +240,7 @@ test_that("best method returns top n results with minimization and ties", {
 
   archive = ArchiveBatch$new(PS_2D, FUN_2D_CODOMAIN)
   xdt = data.table(x1 = runif(5), x2 = runif(5))
-  xss_trafoed = list(list(x1 = runif(5), x2 = runif(5)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y = c(1, 0.25, 0.5, 0.3, 0.3))
   archive$add_evals(xdt, xss_trafoed, ydt)
 
@@ -251,7 +251,7 @@ test_that("best method errors with direction=0 (learn tag)", {
   codomain = ps(y = p_dbl(tags = "learn"))
   archive = ArchiveBatch$new(PS_2D, codomain)
   xdt = data.table(x1 = runif(3), x2 = runif(3))
-  xss_trafoed = list(list(x1 = runif(3), x2 = runif(3)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y = c(1, 0.5, 0.3))
   archive$add_evals(xdt, xss_trafoed, ydt)
 
@@ -262,9 +262,20 @@ test_that("nds_selection errors with direction=0 (learn tag)", {
   codomain = ps(y1 = p_dbl(tags = "learn"), y2 = p_dbl(tags = "minimize"))
   archive = ArchiveBatch$new(PS_2D, codomain)
   xdt = data.table(x1 = runif(3), x2 = runif(3))
-  xss_trafoed = list(list(x1 = runif(3), x2 = runif(3)))
+  xss_trafoed = transpose_list(xdt)
   ydt = data.table(y1 = c(1, 0.5, 0.3), y2 = c(0.3, 0.5, 1))
   archive$add_evals(xdt, xss_trafoed, ydt)
 
   expect_error(archive$nds_selection(n_select = 2), "direction = 0")
+})
+
+test_that("add_evals checks the length of xss_trafoed", {
+  a = ArchiveBatch$new(PS_2D, FUN_2D_CODOMAIN)
+  xdt = data.table(x1 = c(0, 0.5), x2 = c(1, 1))
+  ydt = data.table(y = c(1, 0.25))
+
+  expect_error(a$add_evals(xdt, list(list(x1 = 0, x2 = 1)), ydt), "Must have length 2")
+
+  a$add_evals(xdt, transpose_list(xdt), ydt)
+  expect_equal(a$data$x_domain, transpose_list(xdt))
 })


### PR DESCRIPTION
## Problem

```r
assert_list(xss_trafoed, null.ok = TRUE)
...
set(xydt, j = "x_domain", value = list(xss_trafoed))
```

Nothing related the length of `xss_trafoed` to `nrow(xdt)`, and `set()` recycles:

* two rows with a length-1 list → both rows get the same `x_domain`,
* three rows with a length-2 list → every row's `x_domain` becomes the entire list.

The `x_domain` column is what mlr3tuning and friends read back as the actual configuration, so this is a silently wrong result.

## Fix

`assert_list(xss_trafoed, len = nrow(xdt), null.ok = TRUE)`.

## Tests

The existing tests passed exactly this malformed shape (a length-1 `xss_trafoed` for 2, 3, and 5 row batches), which is why the bug survived; they now build `xss_trafoed` with `transpose_list(xdt)`.
New regression test for the mismatched length and for the stored `x_domain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)