### PR TITLE
fix: wrap non-scalar extras in eval_many

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `Objective$eval_many()` no longer multiplies the number of rows when the objective returns an extra that is an atomic vector of length greater than one (#367).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/Objective.R
+++ b/R/Objective.R
@@ -218,7 +218,8 @@ Objective = R6Class(
     .eval_many = function(xss, ...) {
       res = map_dtr(xss, function(xs) {
         ys = self$eval(xs)
-        as.data.table(lapply(ys, function(y) if (is.list(y) && length(y) > 1) list(y) else y))
+        # everything that is not a scalar is wrapped into a list so that it becomes a single cell of a list column
+        as.data.table(lapply(ys, function(y) if (length(y) != 1L) list(y) else y))
       })
       res
     },

--- a/tests/testthat/test_Objective.R
+++ b/tests/testthat/test_Objective.R
@@ -504,3 +504,22 @@ test_that("codomain direction property works", {
   obj = Objective$new(domain = domain, codomain = codomain)
   expect_equal(obj$codomain$direction, c(y1 = 1L, y2 = -1L, y3 = 0L))
 })
+
+test_that("eval_many wraps extras that are not scalars", {
+  objective = ObjectiveRFun$new(
+    fun = function(xs) list(y = as.numeric(xs$x)^2, extra = c(1, 2, 3)),
+    domain = PS_1D,
+    codomain = FUN_1D_CODOMAIN,
+    properties = "single-crit"
+  )
+
+  ydt = objective$eval_many(list(list(x = 0.5), list(x = 1)))
+  expect_data_table(ydt, nrows = 2L)
+  expect_equal(ydt$y, c(0.25, 1))
+  expect_list(ydt$extra, len = 2L)
+  expect_equal(ydt$extra[[1L]], c(1, 2, 3))
+
+  instance = oi(objective, search_space = PS_1D, terminator = trm("evals", n_evals = 2L))
+  instance$eval_batch(data.table(x = c(0.5, 1)))
+  expect_equal(instance$archive$n_evals, 2L)
+})


### PR DESCRIPTION
## Problem

```r
as.data.table(lapply(ys, function(y) if (is.list(y) && length(y) > 1) list(y) else y))
```

The wrapping only triggered for lists. An objective returning an extra that is an atomic vector of length > 1, e.g. `list(y = 1, extra = c(1, 2, 3))`, produced a three-row `data.table` for a single point, and those three rows went straight into the archive.

## Fix

Wrap everything that is not a scalar: `if (length(y) != 1L) list(y) else y`.
Lists of length > 1 keep behaving as before; atomic vectors and zero-length results now become a single cell of a list column too.

## Tests

New regression test: an objective with `extra = c(1, 2, 3)` evaluated on two points gives two rows, an `extra` list column of length two, and two archive rows through `eval_batch()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)