### PR TITLE
fix: return the optimizer in the object column of mlr_optimizers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `as.data.table(mlr_optimizers, objects = TRUE)` now returns the optimizer in the `object` column instead of `base::t()` for all optimizers but `"chain"` (#368).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/mlr_optimizers.R
+++ b/R/mlr_optimizers.R
@@ -70,7 +70,7 @@ as.data.table.DictionaryOptimizer = function(x, ..., objects = FALSE) {
               properties = list(opt$properties),
               packages = list(opt$packages)
             ),
-            if (objects) list(object = list(t))
+            if (objects) list(object = list(opt))
           )
         }
       },

--- a/tests/testthat/test_mlr_optimizers.R
+++ b/tests/testthat/test_mlr_optimizers.R
@@ -20,5 +20,5 @@ test_that("mlr_optimizers sugar", {
 test_that("as.data.table objects parameter", {
   tab = as.data.table(mlr_optimizers, objects = TRUE)
   expect_data_table(tab)
-  expect_list(tab$object, any.missing = FALSE)
+  expect_list(tab$object, any.missing = FALSE, types = "Optimizer")
 })


### PR DESCRIPTION
## Problem

```r
insert_named(
  list(key = key, ...),
  if (objects) list(object = list(t))   # typo for `opt`
)
```

`as.data.table(mlr_optimizers, objects = TRUE)$object` contained `base::t` for every key except `"chain"` (whose branch spells `opt` correctly).

The existing test passed because `expect_list(tab$object, any.missing = FALSE)` is happy with any non-missing value, and a function is not missing.

## Fix

`list(object = list(opt))`.

## Tests

The existing test now asserts `types = "Optimizer"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)