### PR TITLE
fix: add the noise term to the branin function value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `branin()` now adds the `noise` argument to the function value, which was ignored (#369).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/helper.R
+++ b/R/helper.R
@@ -113,7 +113,9 @@ search_start = function(search_space, type = "random") {
 #'
 #' @param x1 (`numeric()`).
 #' @param x2 (`numeric()`).
-#' @param noise (`numeric()`).
+#' @param noise (`numeric()`)\cr
+#'   Noise term that is added to the function value.
+#'   Default is `0`.
 #' @param fidelity (`numeric()`).
 #'
 #' @return `numeric()`
@@ -123,7 +125,7 @@ search_start = function(search_space, type = "random") {
 #' branin(x1 = 12, x2 = 2, noise = 0.05)
 #' branin_wu(x1 = 12, x2 = 2, fidelity = 1)
 branin = function(x1, x2, noise = 0) {
-  (x2 - 5.1 / (4 * pi^2) * x1^2 + 5 / pi * x1 - 6)^2 + 10 * (1 - 1 / (8 * pi)) * cos(x1) + 10
+  (x2 - 5.1 / (4 * pi^2) * x1^2 + 5 / pi * x1 - 6)^2 + 10 * (1 - 1 / (8 * pi)) * cos(x1) + 10 + noise
 }
 
 #' @rdname branin

--- a/man/branin.Rd
+++ b/man/branin.Rd
@@ -19,7 +19,9 @@ branin_wu(x1, x2, fidelity)
 
 \item{x2}{(\code{numeric()}).}
 
-\item{noise}{(\code{numeric()}).}
+\item{noise}{(\code{numeric()})\cr
+Noise term that is added to the function value.
+Default is \code{0}.}
 
 \item{fidelity}{(\code{numeric()}).}
 }

--- a/tests/testthat/test_mlr_test_functions.R
+++ b/tests/testthat/test_mlr_test_functions.R
@@ -49,3 +49,11 @@ test_that("branin_wu fidelity constant works", {
   val_low = obj$eval(xs)$y
   expect_true(val_full != val_low)
 })
+
+test_that("branin adds the noise term", {
+  expect_equal(branin(x1 = 12, x2 = 2, noise = 0.05), branin(x1 = 12, x2 = 2) + 0.05)
+  expect_equal(
+    branin(x1 = c(12, 0), x2 = c(2, 1), noise = c(0.05, -1)),
+    branin(x1 = c(12, 0), x2 = c(2, 1)) + c(0.05, -1)
+  )
+})


### PR DESCRIPTION
## Problem

```r
branin = function(x1, x2, noise = 0) {
  (x2 - 5.1 / (4 * pi^2) * x1^2 + 5 / pi * x1 - 6)^2 + 10 * (1 - 1 / (8 * pi)) * cos(x1) + 10
}
```

`noise` was never used. The function documents itself as the "classic 2-D Branin function with noise" and the example `branin(x1 = 12, x2 = 2, noise = 0.05)` returns the noiseless value.

This matters beyond the function itself: the irace examples and all five irace tests build their racing "instances" from this argument

```r
data.table(y = branin(xdt[["x1"]], xdt[["x2"]], noise = as.numeric(instances)))
```

so every instance was the same deterministic objective while the tests claimed to exercise noisy instances.

## Fix

Add `noise` to the function value, and document it as the noise term added to the function value.

## Tests

New regression test that the returned value equals the noiseless value plus `noise`, scalar and vectorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)