### PR TITLE
fix: reject empty batches in random search and eval_batch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `OptimizerBatchRandomSearch` rejects a `batch_size` smaller than 1, and `$eval_batch()` errors on an empty `xdt` unless the search space is empty. `opt("random_search", batch_size = 0)` looped forever before (#370).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimInstanceBatch.R
+++ b/R/OptimInstanceBatch.R
@@ -90,6 +90,9 @@ OptimInstanceBatch = R6Class(
         terminated_error(self)
       }
       assert_data_table(xdt)
+      if (!nrow(xdt) && self$search_space$length) {
+        error_bbotk("`xdt` must contain at least one point unless the search space is empty")
+      }
       assert_names(colnames(xdt), must.include = self$search_space$ids())
 
       lg$info("Evaluating %i configuration(s)", max(1, nrow(xdt)))

--- a/R/OptimizerBatchRandomSearch.R
+++ b/R/OptimizerBatchRandomSearch.R
@@ -76,7 +76,7 @@ OptimizerBatchRandomSearch = R6Class(
     #' Creates a new instance of this [R6][R6::R6Class] class.
     initialize = function() {
       param_set = ps(
-        batch_size = p_int(init = 1L, tags = "required")
+        batch_size = p_int(lower = 1L, init = 1L, tags = "required")
       )
 
       super$initialize(

--- a/tests/testthat/test_OptimInstanceBatchSingleCrit.R
+++ b/tests/testthat/test_OptimInstanceBatchSingleCrit.R
@@ -232,3 +232,9 @@ test_that("context deep clone", {
   inst_copy = inst$clone(deep = TRUE)
   expect_null(inst_copy$objective$context)
 })
+
+test_that("eval_batch rejects an empty design", {
+  instance = MAKE_INST_1D(trm("evals", n_evals = 10L))
+  expect_error(instance$eval_batch(data.table(x = numeric(0))), "at least one point")
+  expect_equal(instance$archive$n_evals, 0L)
+})

--- a/tests/testthat/test_OptimizerBatchRandomSearch.R
+++ b/tests/testthat/test_OptimizerBatchRandomSearch.R
@@ -15,3 +15,7 @@ test_that("OptimizerBatchRandomSearch", {
 
   z = test_optimizer_dependencies("random_search", term_evals = 10L, batch_size = 10L)
 })
+
+test_that("OptimizerBatchRandomSearch batch_size must be positive", {
+  expect_error(opt("random_search", batch_size = 0L), "batch_size")
+})


### PR DESCRIPTION
## Problem

`opt("random_search", batch_size = 0)` loops forever.

* `batch_size = p_int(init = 1L, tags = "required")` has no lower bound, while grid search and design points both use `p_int(lower = 1L, ...)`.
* Each iteration proposes a zero-row design, and `eval_batch()` treats `nrow(xdt) == 0` as "the search space is empty" and evaluates `list(list())`.

So the archive never grows, no terminator ever fires, and there is no output at all.

## Fix

* `batch_size = p_int(lower = 1L, init = 1L, tags = "required")`.
* `eval_batch()` raises `error_bbotk()` on an `xdt` without rows unless `search_space$length == 0` (the empty search space case stays supported).

## Tests

* `opt("random_search", batch_size = 0L)` errors.
* `eval_batch(data.table(x = numeric(0)))` errors and leaves the archive empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)