### PR TITLE
fix: return only target values from result_y of single-crit instances

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `$result_y` of the single-criteria instances now only returns the target values of the codomain. It errored for a codomain with additional non-target parameters (#371).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimInstanceAsyncSingleCrit.R
+++ b/R/OptimInstanceAsyncSingleCrit.R
@@ -136,7 +136,7 @@ OptimInstanceAsyncSingleCrit = R6Class(
     #' @field result_y (`numeric()`)\cr
     #' Optimal outcome.
     result_y = function() {
-      unlist(private$.result[, self$objective$codomain$ids(), with = FALSE])
+      unlist(private$.result[, self$objective$codomain$target_ids, with = FALSE])
     }
   ),
 

--- a/R/OptimInstanceBatch.R
+++ b/R/OptimInstanceBatch.R
@@ -154,7 +154,7 @@ OptimInstanceBatch = R6Class(
     #' @field result_y (`numeric()`)\cr
     #' Optimal outcome.
     result_y = function() {
-      unlist(private$.result[, self$objective$codomain$ids(), with = FALSE])
+      unlist(private$.result[, self$objective$codomain$target_ids, with = FALSE])
     },
 
     #' @field is_terminated (`logical(1)`).

--- a/tests/testthat/test_OptimInstanceBatchSingleCrit.R
+++ b/tests/testthat/test_OptimInstanceBatchSingleCrit.R
@@ -232,3 +232,18 @@ test_that("context deep clone", {
   inst_copy = inst$clone(deep = TRUE)
   expect_null(inst_copy$objective$context)
 })
+
+test_that("result_y ignores non-target codomain parameters", {
+  objective = ObjectiveRFun$new(
+    fun = function(xs) list(y = as.numeric(xs$x)^2, time = 1),
+    domain = PS_1D,
+    codomain = ps(y = p_dbl(tags = "minimize"), time = p_dbl()),
+    properties = "single-crit"
+  )
+
+  instance = oi(objective, search_space = PS_1D, terminator = trm("evals", n_evals = 3L))
+  opt("random_search")$optimize(instance)
+
+  expect_equal(names(instance$result_y), "y")
+  expect_number(instance$result_y)
+})


### PR DESCRIPTION
## Problem

```r
result_y = function() {
  unlist(private$.result[, self$objective$codomain$ids(), with = FALSE])
}
```

`$assign_result()` stores only `codomain$target_ids`, so a codomain with an extra non-target parameter breaks on read:

```r
codomain = ps(y = p_dbl(tags = "minimize"), time = p_dbl())
# optimize() succeeds
instance$result_y
#> Error: column not found: [time]
```

`Codomain` documents that parameters without a `minimize`/`maximize` tag are ignored for optimization, and `archive$cols_y` already uses `target_ids`.

## Fix

`$result_y` selects `codomain$target_ids` in `OptimInstanceBatch` and `OptimInstanceAsyncSingleCrit`.

The same line exists in the multi-criteria instances; it is fixed together with their `$assign_result()`, which rejects such a codomain outright, in a separate PR.

## Tests

New regression test: an objective with `ps(y = p_dbl(tags = "minimize"), time = p_dbl())` optimizes and `instance$result_y` is the single named `y` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)