### PR TITLE
fix: expect only target values in multi-crit assign_result

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `$assign_result()` and `$result_y` of the multi-criteria instances now only expect and return the target values of the codomain. A codomain with additional non-target parameters made `$optimize()` fail (#372).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimInstanceAsyncMultiCrit.R
+++ b/R/OptimInstanceAsyncMultiCrit.R
@@ -110,7 +110,7 @@ OptimInstanceAsyncMultiCrit = R6Class(
       assert_data_table(private$.result_xdt)
       assert_names(names(private$.result_xdt), must.include = self$search_space$ids())
       assert_data_table(private$.result_ydt)
-      assert_names(names(private$.result_ydt), permutation.of = self$objective$codomain$ids())
+      assert_names(names(private$.result_ydt), permutation.of = self$objective$codomain$target_ids)
       assert_data_table(private$.result_extra, null.ok = TRUE)
 
       # add x_domain to result
@@ -134,7 +134,7 @@ OptimInstanceAsyncMultiCrit = R6Class(
     #' @field result_y (`numeric(1)`)\cr
     #' Optimal outcome.
     result_y = function() {
-      private$.result[, self$objective$codomain$ids(), with = FALSE]
+      private$.result[, self$objective$codomain$target_ids, with = FALSE]
     }
   ),
 

--- a/R/OptimInstanceBatchMultiCrit.R
+++ b/R/OptimInstanceBatchMultiCrit.R
@@ -95,7 +95,7 @@ OptimInstanceBatchMultiCrit = R6Class(
       assert_data_table(private$.result_xdt)
       assert_names(names(private$.result_xdt), must.include = self$search_space$ids())
       assert_data_table(private$.result_ydt)
-      assert_names(names(private$.result_ydt), permutation.of = self$objective$codomain$ids())
+      assert_names(names(private$.result_ydt), permutation.of = self$objective$codomain$target_ids)
       assert_data_table(private$.result_extra, null.ok = TRUE)
 
       # add x_domain to result
@@ -119,7 +119,7 @@ OptimInstanceBatchMultiCrit = R6Class(
     #' @field result_y (`numeric(1)`)\cr
     #' Optimal outcome.
     result_y = function() {
-      private$.result[, self$objective$codomain$ids(), with = FALSE]
+      private$.result[, self$objective$codomain$target_ids, with = FALSE]
     }
   ),
 

--- a/tests/testthat/test_OptimInstanceBatchMultiCrit.R
+++ b/tests/testthat/test_OptimInstanceBatchMultiCrit.R
@@ -76,3 +76,18 @@ test_that("OptimInstanceBatchMultiCrit works with empty search space", {
   expect_data_table(instance$archive$data, nrows = 1)
   expect_equal(instance$result$x_domain[[1]], list())
 })
+
+test_that("assign_result ignores non-target codomain parameters", {
+  objective = ObjectiveRFun$new(
+    fun = function(xs) list(y1 = as.numeric(xs$x)^2, y2 = -as.numeric(xs$x)^2, time = 1),
+    domain = PS_1D,
+    codomain = ps(y1 = p_dbl(tags = "minimize"), y2 = p_dbl(tags = "minimize"), time = p_dbl()),
+    properties = "multi-crit"
+  )
+
+  instance = oi(objective, search_space = PS_1D, terminator = trm("evals", n_evals = 3L))
+  opt("random_search")$optimize(instance)
+
+  expect_names(names(instance$result_y), identical.to = c("y1", "y2"))
+  expect_data_table(instance$result, min.rows = 1L)
+})


### PR DESCRIPTION
## Problem

```r
assert_names(names(private$.result_ydt), permutation.of = self$objective$codomain$ids())
```

`assign_result_default()` passes `xydt[, inst$archive$cols_y]`, and `cols_y` is `codomain$target_ids`.
A three-column codomain such as `ps(y1 = p_dbl(tags = "minimize"), y2 = p_dbl(tags = "minimize"), time = p_dbl())` therefore made `$optimize()` fail outright, even though `Codomain` documents non-target parameters as ignored.
The single-criteria sibling uses `target_ids`.

`$result_y` has the same problem: it selected `codomain$ids()` from a result that only ever contains the target values.

## Fix

Both `$assign_result()` and `$result_y` use `codomain$target_ids`, in `OptimInstanceBatchMultiCrit` and `OptimInstanceAsyncMultiCrit`.

## Tests

New regression test: a multi-criteria objective with an extra `time` codomain parameter optimizes and `instance$result_y` contains exactly `y1` and `y2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)