### PR TITLE
fix: dispatch bb_optimize on the number of codomain targets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `bb_optimize()` now creates a single-criteria instance for a codomain with one target and additional non-target parameters instead of a multi-criteria instance (#373).
+
 * fix: `$result_y` of the single-criteria instances now only returns the target values of the codomain. It errored for a codomain with additional non-target parameters (#371).
 
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,

--- a/R/bb_optimize.R
+++ b/R/bb_optimize.R
@@ -123,7 +123,7 @@ bb_optimize.Objective = function(
   } else if (!is.null(max_time)) {
     trm("run_time", secs = max_time)
   }
-  optiminstance = if (x$codomain$length == 1) OptimInstanceBatchSingleCrit else OptimInstanceBatchMultiCrit
+  optiminstance = if (x$codomain$target_length == 1) OptimInstanceBatchSingleCrit else OptimInstanceBatchMultiCrit
 
   instance = optiminstance$new(x, terminator = terminator, search_space = search_space, check_values = FALSE)
   optimizer$optimize(instance)

--- a/tests/testthat/test_bb_optimize.R
+++ b/tests/testthat/test_bb_optimize.R
@@ -153,3 +153,17 @@ test_that("bb_optimize works with objective", {
   expect_named(res$value, "z")
   expect_r6(res$instance, "OptimInstanceBatchSingleCrit")
 })
+
+test_that("bb_optimize dispatches on the number of targets in the codomain", {
+  objective = ObjectiveRFun$new(
+    fun = function(xs) list(y = as.numeric(xs$x)^2, time = 1),
+    domain = PS_1D,
+    codomain = ps(y = p_dbl(tags = "minimize"), time = p_dbl()),
+    properties = "single-crit"
+  )
+
+  result = bb_optimize(objective, method = "random_search", max_evals = 5L)
+
+  expect_class(result$instance, "OptimInstanceBatchSingleCrit")
+  expect_names(names(result$value), identical.to = "y")
+})


### PR DESCRIPTION
> Stacked on #371 (the `result_y` fix), because `bb_optimize()` reads `instance$result_y` before returning. Merge #371 first, or merge this into it.

## Problem

```r
optiminstance = if (x$codomain$length == 1) OptimInstanceBatchSingleCrit else OptimInstanceBatchMultiCrit
```

A codomain with a single target and one additional non-target parameter, e.g. `ps(y = p_dbl(tags = "minimize"), time = p_dbl())`, has `length == 2` and was routed to the multi-criteria instance, where it fails.
`oi()` dispatches on `codomain$target_length` and gets this right.

## Fix

Dispatch on `x$codomain$target_length`.

## Tests

New regression test: `bb_optimize()` on such an objective returns an `OptimInstanceBatchSingleCrit` and a `value` holding only `y`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)