### PR TITLE
fix: allow replacing context$xdt in a batch callback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `context$xdt` can now be replaced by assignment in the `on_optimizer_before_eval` stage of a `CallbackBatch`, and the replaced points are both evaluated and written to the archive (#374).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/ContextBatch.R
+++ b/R/ContextBatch.R
@@ -36,7 +36,7 @@ ContextBatch = R6Class(
       if (missing(rhs)) {
         get_private(self$instance)$.xdt
       } else {
-        get_private(self$instance)$.xdt = rhs
+        get_private(self$instance, ".xdt") = rhs
       }
     },
 

--- a/R/OptimInstanceBatch.R
+++ b/R/OptimInstanceBatch.R
@@ -81,6 +81,8 @@ OptimInstanceBatch = R6Class(
         private$.initialize_context(NULL)
       }
       call_back("on_optimizer_before_eval", self$objective$callbacks, self$objective$context)
+      # the callbacks may have replaced the points
+      xdt = private$.xdt
       # update progressor
       if (!is.null(self$progressor)) {
         self$progressor$update(self$terminator, self$archive)
@@ -102,9 +104,9 @@ OptimInstanceBatch = R6Class(
       ) {
         # if search space has no transformation function and dependencies, and the objective takes a data table
         # use shortcut to skip conversion between data table and list
-        ydt = self$objective$eval_dt(private$.xdt[, self$search_space$ids(), with = FALSE])
+        ydt = self$objective$eval_dt(xdt[, self$search_space$ids(), with = FALSE])
       } else {
-        xss_trafoed = transform_xdt_to_xss(private$.xdt, self$search_space)
+        xss_trafoed = transform_xdt_to_xss(xdt, self$search_space)
         ydt = self$objective$eval_many(xss_trafoed)
       }
 

--- a/tests/testthat/test_CallbackBatch.R
+++ b/tests/testthat/test_CallbackBatch.R
@@ -205,3 +205,22 @@ test_that("on_result in OptimInstanceBatchMultiCrit works", {
   expect_equal(unique(instance$result$y1), 2)
   expect_equal(unique(instance$result$y2), 3)
 })
+
+test_that("xdt can be replaced in on_optimizer_before_eval", {
+  callback = callback_batch(
+    id = "replace_xdt",
+    on_optimizer_before_eval = function(callback, context) {
+      context$xdt = data.table(x = rep(0.5, nrow(context$xdt)))
+    }
+  )
+
+  instance = oi(
+    OBJ_1D,
+    search_space = PS_1D,
+    terminator = trm("evals", n_evals = 4L),
+    callbacks = callback
+  )
+  opt("random_search", batch_size = 2L)$optimize(instance)
+
+  expect_true(all(instance$archive$data$x == 0.5))
+})


### PR DESCRIPTION
## Problem

```r
xdt = function(rhs) {
  if (missing(rhs)) get_private(self$instance)$.xdt else get_private(self$instance)$.xdt = rhs
}
```

R rewrites the assignment form into a call of `` `get_private<-`(x, value) ``, without `which`, so `context$xdt = ...` failed with `argument "which" is missing, with no default`.
The field is documented as modifiable in `on_optimizer_before_eval`, and the two neighbouring bindings in the same file already use the working idiom `get_private(x, ".field") = rhs`.

The existing tests only mutated the points in place with `set()`, where `xdt` and `private$.xdt` are the same object, so nobody hit it.

## Fix

* Use `get_private(self$instance, ".xdt") = rhs`.
* `$eval_batch()` used both references inconsistently: the objective was called with `private$.xdt`, while the assertions, the archive, and the log used the local `xdt` argument. With a genuinely replaced `xdt` this would have evaluated the new points and stored the old ones. It now reads `private$.xdt` back once, after the callbacks have run.

## Tests

New regression test: a callback that replaces `context$xdt` with a constant point in `on_optimizer_before_eval`, and every archive row carries the replaced value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)