### PR TITLE
fix: check terminator support against the codomain

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `assert_terminable()` now decides whether an instance is single or multi-criteria from the codomain of the objective instead of the class of the instance, so terminators are checked correctly for `OptimInstanceAsyncMultiCrit` (#375).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimInstance.R
+++ b/R/OptimInstance.R
@@ -47,7 +47,7 @@ OptimInstance = R6Class(
       assert_r6(objective, "Objective")
       objective$callbacks = assert_callbacks(as_callbacks(callbacks))
       assert_param_set(search_space)
-      terminator = assert_terminator(terminator, self)
+      terminator = assert_terminator(terminator)
       assert_flag(check_values)
       assert_r6(archive, "Archive")
 
@@ -59,6 +59,9 @@ OptimInstance = R6Class(
         label = label,
         man = man
       )
+
+      # the objective is only available after the fields are initialized
+      assert_terminable(terminator, self)
     },
 
     #' @description

--- a/R/assertions.R
+++ b/R/assertions.R
@@ -51,7 +51,7 @@ assert_terminators = function(terminators) {
 #' @param instance ([OptimInstance]).
 #' @rdname bbotk_assertions
 assert_terminable = function(terminator, instance) {
-  if ("OptimInstanceBatchMultiCrit" %in% class(instance)) {
+  if (instance$objective$codomain$target_length > 1L) {
     if (!"multi-crit" %in% terminator$properties) {
       stopf("Terminator '%s' does not support multi-crit optimization", terminator$format())
     }

--- a/tests/testthat/test_OptimInstanceAsyncMultiCrit.R
+++ b/tests/testthat/test_OptimInstanceAsyncMultiCrit.R
@@ -1,0 +1,47 @@
+skip_if_not_installed("rush")
+skip_if_no_redis()
+
+test_that("initializing OptimInstanceAsyncMultiCrit works", {
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = oi_async(
+    objective = OBJ_2D_2D,
+    search_space = PS_2D,
+    terminator = trm("evals", n_evals = 5L),
+    rush = rush
+  )
+
+  expect_r6(instance, "OptimInstanceAsyncMultiCrit")
+  expect_r6(instance$archive, "ArchiveAsync")
+  expect_null(instance$result)
+})
+
+test_that("terminators are checked against the codomain of an async multi-crit instance", {
+  rush = start_rush()
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  expect_error(
+    oi_async(
+      objective = OBJ_2D_2D,
+      search_space = PS_2D,
+      terminator = trm("perf_reached", level = 0.1),
+      rush = rush
+    ),
+    "does not support multi-crit"
+  )
+
+  instance = oi_async(
+    objective = OBJ_2D_2D,
+    search_space = PS_2D,
+    terminator = trm("stagnation_hypervolume"),
+    rush = rush
+  )
+  expect_r6(instance$terminator, "TerminatorStagnationHypervolume")
+})


### PR DESCRIPTION
## Problem

```r
assert_terminable = function(terminator, instance) {
  if ("OptimInstanceBatchMultiCrit" %in% class(instance)) {
    ... "multi-crit" ...
  } else {
    ... "single-crit" ...
  }
}
```

`OptimInstanceAsyncMultiCrit` does not carry that class, so an async multi-criteria instance was checked as single-criteria:

* `trm("stagnation_hypervolume")` (properties `"multi-crit"`) was rejected at construction,
* `trm("perf_reached")` (properties `"single-crit"`) was accepted and then errored on the rush workers, where the failure is much harder to read.

## Fix

Branch on `instance$objective$codomain$target_length`, which is what every other single/multi decision in the package uses.

`OptimInstance$initialize()` called `assert_terminator(terminator, self)` before `super$initialize()`, i.e. before `self$objective` exists, so the terminability check moves after `super$initialize()`; the plain `assert_terminator()` class check stays where it was.

## Tests

New `test_OptimInstanceAsyncMultiCrit.R` (the class had no tests at all): construction, plus `trm("perf_reached")` rejected and `trm("stagnation_hypervolume")` accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)