### PR TITLE
fix: report integer steps in TerminatorRunTime status

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `TerminatorRunTime` now reports an integer number of steps, so a fractional `secs` value no longer breaks `$optimize()` when progressr is loaded (#376).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/TerminatorRunTime.R
+++ b/R/TerminatorRunTime.R
@@ -64,7 +64,7 @@ TerminatorRunTime = R6Class(
 
   private = list(
     .status = function(archive) {
-      max_steps = self$param_set$values$secs
+      max_steps = as.integer(ceiling(self$param_set$values$secs))
       current_steps = as.integer(difftime(Sys.time(), archive$start_time, units = "secs"))
       c("max_steps" = max_steps, "current_steps" = current_steps)
     }

--- a/tests/testthat/test_TerminatorRunTime.R
+++ b/tests/testthat/test_TerminatorRunTime.R
@@ -21,6 +21,19 @@ test_that("max and current works", {
   expect_equal(inst$terminator$status(inst$archive)["max_steps"], c("max_steps" = 3))
 })
 
+test_that("fractional secs work with progressr", {
+  skip_if_not_installed("progressr")
+  requireNamespace("progressr")
+
+  terminator = trm("run_time", secs = 0.5)
+  inst = MAKE_INST_1D(terminator = terminator)
+  expect_equal(terminator$status(inst$archive)["max_steps"], c("max_steps" = 1L))
+
+  optimizer = opt("random_search")
+  progressr::with_progress(optimizer$optimize(inst))
+  expect_gte(inst$archive$n_evals, 1L)
+})
+
 test_that("TerminatorRunTime works with empty archive", {
   terminator = TerminatorRunTime$new()
   archive = ArchiveBatch$new(ps(x = p_dbl()), ps(y = p_dbl(tags = "minimize")))


### PR DESCRIPTION
## Problem

```r
# TerminatorRunTime
.status = function(archive) {
  max_steps = self$param_set$values$secs   # p_dbl
  ...
}

# optimize_batch_default
max_steps = assert_int(instance$terminator$status(instance$archive)["max_steps"])
```

`trm("run_time", secs = 0.5)` broke `$optimize()` with an `assert_int` failure, but only if the progressr namespace happened to be loaded, which makes it look like a progressr problem.

## Fix

`max_steps = as.integer(ceiling(self$param_set$values$secs))`, the same rounding `TerminatorClockTime$.status()` already does.

## Tests

New regression test: `secs = 0.5` reports `max_steps = 1` and optimizes inside `progressr::with_progress()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)