### PR TITLE
fix: give a readable error when nothing was evaluated

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `assign_result_default()` now raises a readable error when the terminator is already terminated before the first evaluation instead of failing with `column not found` (#377).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/Optimizer.R
+++ b/R/Optimizer.R
@@ -186,6 +186,16 @@ Optimizer = R6Class(
 assign_result_default = function(inst) {
   assert_r6(inst, "OptimInstance")
 
+  if (!inst$archive$n_evals) {
+    error_bbotk(
+      paste0(
+        "No point was evaluated, so no result can be assigned.",
+        " The terminator '%s' terminated before the first evaluation."
+      ),
+      class(inst$terminator)[1L]
+    )
+  }
+
   xydt = inst$archive$best()
   cols_x = inst$archive$cols_x
   cols_y = inst$archive$cols_y

--- a/tests/testthat/test_Optimizer.R
+++ b/tests/testthat/test_Optimizer.R
@@ -43,3 +43,13 @@ test_that("optimize return works", {
   z = optimizer$optimize(instance)
   expect_equal(z, instance$result)
 })
+
+test_that("assign_result_default errors on an empty archive", {
+  instance = MAKE_INST_1D(trm("evals", n_evals = 0L))
+
+  expect_error(
+    opt("random_search")$optimize(instance),
+    "No point was evaluated",
+    class = "Mlr3ErrorBbotk"
+  )
+})


### PR DESCRIPTION
## Problem

A terminator that already terminates before the first batch leaves the archive empty:

```r
instance = oi(objective, terminator = trm("evals", n_evals = 0))
opt("random_search")$optimize(instance)
#> Error: column not found: [x]
```

`ArchiveBatch$best()` guards the empty case by returning `data.table()`, and `assign_result_default()` then indexes `cols_x` on it.
A `clock_time` in the past produces the same message.

## Fix

`assign_result_default()` raises `error_bbotk()` naming the terminator when the archive holds no evaluation.

## Tests

New regression test: `trm("evals", n_evals = 0L)` errors with class `Mlr3ErrorBbotk` and a message about no evaluated point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)