### PR TITLE
fix: recognize the termination condition in local search

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `local_search()` now recognizes the termination condition raised by a terminator. The condition was re-raised and the RNG state was never written back, so all random numbers drawn in the C code were lost (#378).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/src/local_search.c
+++ b/src/local_search.c
@@ -272,10 +272,11 @@ SEXP try_eval(void *data) {
 
 // internal function to handle what happens in the catch block
 // if the terminator triggers, we return NIL, otherwise we raise error back to R
+// "terminated_error" is the legacy class of the termination condition, see R/conditions.R
 SEXP catch_condition(SEXP s_condition, void *data) {
     DEBUG_PRINT("Caught R condition of class: %s\n",
         CHAR(STRING_ELT(Rf_getAttrib(s_condition, R_ClassSymbol), 0)));
-    if (!Rf_inherits(s_condition, "terminator_exception")) {
+    if (!Rf_inherits(s_condition, "Mlr3ErrorBbotkTerminated") && !Rf_inherits(s_condition, "terminated_error")) {
         SEXP stop_call = PROTECT(Rf_lang2(Rf_install("stop"), s_condition));
         Rf_eval(stop_call, R_GlobalEnv);
         UNPROTECT(1); // stop_call

--- a/tests/testthat/test_OptimizerBatchLocalSearch.R
+++ b/tests/testthat/test_OptimizerBatchLocalSearch.R
@@ -435,3 +435,26 @@ test_that("OptimizerBatchLocalSearch works with CondAnyOf", {
   }
   if (nrow(dt[x1 %in% c("a", "b")])) expect_true(all(!is.na(dt[x1 %in% c("a", "b")]$x2)))
 })
+
+test_that("local_search catches the termination condition and restores the RNG state", {
+  search_space = ps(x = p_dbl(-1, 1))
+  control = local_search_control(n_searches = 2L, n_steps = 5L, n_neighs = 3L)
+  init_points = data.table(x = c(-0.5, 0.5))
+
+  n_calls = 0L
+  objective = function(xdt) {
+    n_calls <<- n_calls + 1L
+    if (n_calls > 1L) error_bbotk_terminated("terminated")
+    xdt$x^2
+  }
+
+
+  set.seed(1)
+  before = get(".Random.seed", envir = globalenv())
+  res = local_search(objective, search_space, control, init_points)
+  after = get(".Random.seed", envir = globalenv())
+
+  expect_names(names(res), identical.to = c("x", "y"))
+  # the C code draws random numbers before the objective terminates, so the RNG state must have moved on
+  expect_false(identical(before, after))
+})


### PR DESCRIPTION
## Problem

```c
if (!Rf_inherits(s_condition, "terminator_exception")) {
    SEXP stop_call = PROTECT(Rf_lang2(Rf_install("stop"), s_condition));
    Rf_eval(stop_call, R_GlobalEnv);
    ...
}
```

bbotk raises `Mlr3ErrorBbotkTerminated` / `Mlr3ErrorBbotk` / `terminated_error` (see `R/conditions.R`); `terminator_exception` does not exist.

So every terminator-triggered stop took the re-raise branch, and the `stop()` longjmps out of `c_local_search()` past the `PutRNGstate()` at the end of the function. All random numbers the C code consumed for mutation and restarts were discarded, `.Random.seed` was left at the state before the search, and subsequent random calls in R replayed the same numbers.

## Fix

Check for the classes bbotk actually raises. The comment notes that `terminated_error` is the legacy class kept for downstream `tryCatch()` handlers, so both are accepted.

## Tests

New regression test: `local_search()` with an objective that raises `error_bbotk_terminated()` on its second call returns normally and leaves the RNG state advanced. Without the fix, the condition escapes and the seed is byte-identical to the state before the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)