### PR TITLE
fix: sync the RNG state around the objective call in local search

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `local_search()` now writes the RNG state back before it calls the objective, so an objective that draws random numbers no longer receives the numbers the C code consumed for mutation (#379).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/src/local_search.c
+++ b/src/local_search.c
@@ -641,7 +641,10 @@ void copy_best_neighs_to_pop(SEXP s_neighs_x, double* neighs_y,
 
 int eval_obj(int n, SEXP s_x, SEXP s_obj, double* y, const Control* ctrl) {
     SEXP s_call = PROTECT(Rf_lang2(s_obj, s_x));
+    // the RNG state must be written back before we call into R, because the objective may draw random numbers itself
+    PutRNGstate();
     SEXP s_y = PROTECT(safe_eval(s_call));
+    GetRNGstate();
     int eval_ok = 0;
     if (s_y != R_NilValue) {
         memcpy(y, REAL(s_y), n * sizeof(double));

--- a/tests/testthat/test_OptimizerBatchLocalSearch.R
+++ b/tests/testthat/test_OptimizerBatchLocalSearch.R
@@ -435,3 +435,26 @@ test_that("OptimizerBatchLocalSearch works with CondAnyOf", {
   }
   if (nrow(dt[x1 %in% c("a", "b")])) expect_true(all(!is.na(dt[x1 %in% c("a", "b")]$x2)))
 })
+
+test_that("local_search does not replay its random numbers in the objective", {
+  search_space = ps(x = p_dbl(-1, 1))
+  control = local_search_control(n_searches = 2L, n_steps = 2L, n_neighs = 3L)
+  init_points = data.table(x = c(-0.5, 0.5))
+
+  draws = numeric(0)
+  objective = function(xdt) {
+    draws <<- c(draws, runif(1L))
+    xdt$x^2
+  }
+
+  set.seed(1)
+  local_search(objective, search_space, control, init_points)
+  expect_gte(length(draws), 2L)
+
+  set.seed(1)
+  reference = runif(length(draws))
+  # the first call happens before the C code draws anything
+  expect_equal(draws[1L], reference[1L])
+  # afterwards the objective must continue behind the numbers the C code consumed
+  expect_false(draws[2L] == reference[2L])
+})


### PR DESCRIPTION
## Problem

`eval_obj()` evaluates the R objective while the RNG state is checked out into the C side:

```c
GetRNGstate();          // in c_local_search
...
SEXP s_y = PROTECT(safe_eval(s_call));   // calls back into R
...
PutRNGstate();          // in c_local_search
```

R's `.Random.seed` is untouched for the whole search, so an objective that draws random numbers starts from the state before the search and receives exactly the numbers the C code is consuming for mutation and restarts. Writing R Extensions requires `PutRNGstate()` before and `GetRNGstate()` after any callback into R.

## Fix

Bracket the callback in `eval_obj()` with `PutRNGstate()` / `GetRNGstate()`.

## Tests

New regression test: an objective drawing `runif(1)` per call. The first call still sees the first number of the seeded stream (no C draws happened yet), and every later call must be *behind* the numbers the C code consumed. Without the fix, the objective's draws are byte-for-byte the plain `runif()` sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)