### PR TITLE
fix: compare names exactly in the local search C code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: The C code of `local_search()` now compares parameter names, column names, list element names, and factor levels exactly instead of by prefix. A parameter or level whose name was a prefix of another one aborted the R session or made mutation a silent no-op (#380).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/src/local_search.c
+++ b/src/local_search.c
@@ -230,9 +230,7 @@ void dt_mutate_element(SEXP s_dt, int row_i, int param_j, const SearchSpace* ss,
             // Find current level index
             const char* current_level = CHAR(STRING_ELT(s_neigh_col, row_i));
             int current_idx = 0;
-            while (current_idx < n_levels &&
-              strncmp(current_level, ss->level_names[param_j][current_idx], strlen(current_level)) != 0)
-            {
+            while (current_idx < n_levels && strcmp(current_level, ss->level_names[param_j][current_idx]) != 0) {
                 current_idx++;
             }
             // Sample from other levels using shift trick
@@ -295,7 +293,7 @@ SEXP safe_eval(SEXP expr) {
 // Find parameter index by name, -1 if not found (should not happen)
 int find_param_index(const char* param_name, const SearchSpace* ss) {
     for (int j = 0; j < ss->n_params; j++) {
-        if (strncmp(ss->param_names[j], param_name, strlen(param_name)) == 0) {
+        if (strcmp(ss->param_names[j], param_name) == 0) {
             return j;
         }
     }

--- a/src/rc_helpers.c
+++ b/src/rc_helpers.c
@@ -30,7 +30,7 @@ SEXP RC_get_list_el_by_name(SEXP s_list, const char *name) {
   SEXP elmt = R_NilValue, names = getAttrib(s_list, R_NamesSymbol);
   int i;
   for (i = 0; i < length(s_list); i++) {
-      if(strncmp(CHAR(STRING_ELT(names, i)), name, strlen(name)) == 0) {
+      if(strcmp(CHAR(STRING_ELT(names, i)), name) == 0) {
           elmt = VECTOR_ELT(s_list, i);
           break;
       }
@@ -49,7 +49,7 @@ R_xlen_t RC_dt_nrows(SEXP s_dt) {
 SEXP RC_get_dt_col_by_name(SEXP s_dt, const char *name) {
   SEXP col_names = getAttrib(s_dt, R_NamesSymbol);
   for (int i = 0; i < length(s_dt); i++) {
-      if (strncmp(CHAR(STRING_ELT(col_names, i)), name, strlen(name)) == 0) {
+      if (strcmp(CHAR(STRING_ELT(col_names, i)), name) == 0) {
           return VECTOR_ELT(s_dt, i);
       }
   }

--- a/tests/testthat/test_OptimizerBatchLocalSearch.R
+++ b/tests/testthat/test_OptimizerBatchLocalSearch.R
@@ -435,3 +435,30 @@ test_that("OptimizerBatchLocalSearch works with CondAnyOf", {
   }
   if (nrow(dt[x1 %in% c("a", "b")])) expect_true(all(!is.na(dt[x1 %in% c("a", "b")]$x2)))
 })
+
+test_that("local_search matches parameter names exactly", {
+  # "a" is a prefix of "ab", which was matched first and produced a self dependency
+  search_space = ps(
+    ab = p_dbl(0, 1, depends = a == "x"),
+    a = p_fct(c("x", "y"))
+  )
+  control = local_search_control(n_searches = 2L, n_steps = 5L, n_neighs = 5L)
+  objective = function(xdt) ifelse(xdt$a == "x", xdt$ab, 1)
+
+  res = local_search(objective, search_space, control)
+
+  expect_names(names(res$x), permutation.of = c("ab", "a"))
+  expect_number(res$y)
+})
+
+test_that("local_search matches factor levels exactly", {
+  # "a" is a prefix of "ab", so mutating away from "a" was a no-op
+  search_space = ps(x = p_fct(c("ab", "a")))
+  control = local_search_control(n_searches = 1L, n_steps = 5L, n_neighs = 1L)
+  objective = function(xdt) as.numeric(xdt$x == "a")
+
+  res = local_search(objective, search_space, control, init_points = data.table(x = "a"))
+
+  expect_equal(res$x$x, "ab")
+  expect_equal(res$y, 0)
+})


### PR DESCRIPTION
## Problem

Four lookups compared only a prefix:

* `src/rc_helpers.c:33` `RC_get_list_el_by_name()`
* `src/rc_helpers.c:52` `RC_get_dt_col_by_name()`
* `src/local_search.c` `find_param_index()`
* `src/local_search.c` the factor level lookup in `dt_mutate_element()`

all of the shape `strncmp(candidate, name, strlen(name)) == 0`.

Two concrete failures:

1. `ps(ab = p_dbl(0, 1, depends = a == "x"), a = p_fct(c("x", "y")))` — looking up the parent `"a"` returns the index of `"ab"`, which makes `ab` depend on itself. `toposort_params()` then never reaches all parameters, `assert(count == ss->n_params)` fires and **the R process aborts**. In a `-DNDEBUG` build the assert is compiled out and partially uninitialized index arrays are passed to `VECTOR_ELT()`.
2. Factor levels `c("ab", "a")` with the current value `"a"` — the level lookup stops at `"ab"`, and the "sample from the other levels" shift trick then maps the draw straight back onto `"a"`, so mutation is a silent no-op.

## Fix

`strcmp` in all four places. The `strncmp(class_name, "ParamDbl", 8)` comparisons are left alone: they compare against fixed literals of exactly that length.

## Tests

* a search space with the parameters `ab` and `a` and a dependency between them runs (without the fix, the R session aborts on the assertion),
* a factor with the levels `c("ab", "a")` starting at `"a"` mutates to `"ab"` and finds the optimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)