### PR TITLE
fix: check the objective return value in local search

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `local_search()` now checks that the objective returns a numeric vector of the expected length without missing values instead of reading past the end of the returned vector (#381).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/src/local_search.c
+++ b/src/local_search.c
@@ -644,11 +644,23 @@ int eval_obj(int n, SEXP s_x, SEXP s_obj, double* y, const Control* ctrl) {
     SEXP s_y = PROTECT(safe_eval(s_call));
     int eval_ok = 0;
     if (s_y != R_NilValue) {
-        memcpy(y, REAL(s_y), n * sizeof(double));
-        // multiply by obj_mult to handle maximization
-        for (int i = 0; i < n; i++) {
-            y[i] *= ctrl->obj_mult;
+        // Rf_error unwinds the protection stack on its own
+        if (TYPEOF(s_y) != REALSXP && TYPEOF(s_y) != INTSXP) {
+            Rf_error("Objective must return a numeric vector");
         }
+        if (XLENGTH(s_y) != n) {
+            Rf_error("Objective must return %d value(s) but returned %d", n, (int) XLENGTH(s_y));
+        }
+        SEXP s_y_real = PROTECT(Rf_coerceVector(s_y, REALSXP));
+        const double *y_real = REAL(s_y_real);
+        for (int i = 0; i < n; i++) {
+            if (ISNAN(y_real[i])) {
+                Rf_error("Objective must not return missing values");
+            }
+            // multiply by obj_mult to handle maximization
+            y[i] = y_real[i] * ctrl->obj_mult;
+        }
+        UNPROTECT(1); // s_y_real
         eval_ok = 1;
     }
     UNPROTECT(2); // s_call, s_y

--- a/tests/testthat/test_OptimizerBatchLocalSearch.R
+++ b/tests/testthat/test_OptimizerBatchLocalSearch.R
@@ -435,3 +435,25 @@ test_that("OptimizerBatchLocalSearch works with CondAnyOf", {
   }
   if (nrow(dt[x1 %in% c("a", "b")])) expect_true(all(!is.na(dt[x1 %in% c("a", "b")]$x2)))
 })
+
+test_that("local_search checks the return value of the objective", {
+  search_space = ps(x = p_dbl(-1, 1))
+  control = local_search_control(n_searches = 2L, n_steps = 1L, n_neighs = 2L)
+  init_points = data.table(x = c(-0.5, 0.5))
+
+  expect_error(
+    local_search(function(xdt) "a", search_space, control, init_points),
+    "must return a numeric vector"
+  )
+  expect_error(
+    local_search(function(xdt) 1, search_space, control, init_points),
+    "must return 2 value"
+  )
+  expect_error(
+    local_search(function(xdt) rep(NA_real_, nrow(xdt)), search_space, control, init_points),
+    "must not return missing values"
+  )
+  # integer returns are numeric too
+  res = local_search(function(xdt) as.integer(xdt$x > 0), search_space, control, init_points)
+  expect_number(res$y)
+})


### PR DESCRIPTION
## Problem

```c
memcpy(y, REAL(s_y), n * sizeof(double));
```

Nothing checked the type or the length of what the user's objective returned, and `local_search()` is exported.

* a scalar return is a heap over-read and silently yields `y = 0`,
* an integer vector fails inside `REAL()` with `REAL() can only be applied to a 'numeric'`, which does not point at the objective,
* a result of all `NA` leaves the global best at `Inf` and returns `x = list(x = NULL)`.

## Fix

`eval_obj()` now rejects a non-numeric return, a length mismatch, and missing values with messages naming the objective, and coerces an integer return to double.
`Inf` stays allowed: it is a legitimate "as bad as possible" value.

## Tests

New regression tests for a character return, a length-1 return for a two-point batch, an all-`NA` return, and an integer return (accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)