### PR TITLE
fix: raise R errors instead of asserting in the C code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: The C code of `local_search()` now raises R errors instead of using `assert()`, which aborted the R session and vanished entirely in a build with `-DNDEBUG` (#382).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/src/local_search.c
+++ b/src/local_search.c
@@ -5,7 +5,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#include <assert.h>
 
 // print a data.table row (for debugging)
 void dt_print_row(SEXP dt, int row) {
@@ -121,7 +120,7 @@ int dt_is_na(SEXP s_dt, int row_i, int param_j) {
             return STRING_ELT(s_col, row_i) == NA_STRING;
     }
     // this should never happen...
-    assert(0);
+    Rf_error("Unsupported column type in search space");
     return 0;
 }
 
@@ -190,7 +189,9 @@ SEXP dt_generate(int n, SearchSpace* ss) {
 // Helper function mutate a single element of a config (in a DT)
 void dt_mutate_element(SEXP s_dt, int row_i, int param_j, const SearchSpace* ss, const Control* ctrl) {
     // we only mutate elements that are not NA
-    assert(!dt_is_na(s_dt, row_i, param_j));
+    if (dt_is_na(s_dt, row_i, param_j)) {
+        Rf_error("Cannot mutate the inactive parameter '%s'", ss->param_names[param_j]);
+    }
     int param_class = ss->param_classes[param_j];
     SEXP s_neigh_col = VECTOR_ELT(s_dt, param_j);
     if (param_class == 0) { // ParamDbl
@@ -403,10 +404,10 @@ void extract_ctrl_info(SEXP s_ctrl, Control* ctrl) {
     ctrl->n_neighs = asInteger(RC_get_list_el_by_name(s_ctrl, "n_neighs"));
     ctrl->mut_sd = asReal(RC_get_list_el_by_name(s_ctrl, "mut_sd"));
     ctrl->stagnate_max = asInteger(RC_get_list_el_by_name(s_ctrl, "stagnate_max"));
-    assert(ctrl->n_searches > 0);
-    assert(ctrl->n_steps >= 0);
-    assert(ctrl->n_neighs > 0);
-    assert(ctrl->mut_sd > 0);
+    if (ctrl->n_searches <= 0) Rf_error("'n_searches' must be positive");
+    if (ctrl->n_steps < 0) Rf_error("'n_steps' must not be negative");
+    if (ctrl->n_neighs <= 0) Rf_error("'n_neighs' must be positive");
+    if (ctrl->mut_sd <= 0) Rf_error("'mut_sd' must be positive");
 }
 
 
@@ -437,7 +438,9 @@ void toposort_params(SearchSpace* ss) {
             }
         }
     }
-    assert(count == ss->n_params);
+    if (count != ss->n_params) {
+        Rf_error("The dependencies of the search space are cyclic");
+    }
     ss->sorted_param_indices = sorted;
 }
 
@@ -457,7 +460,9 @@ void reorder_conds_by_toposort(SearchSpace* ss) {
             }
         }
     }
-    assert(reordered_count == ss->n_conds);
+    if (reordered_count != ss->n_conds) {
+        Rf_error("The dependencies of the search space are cyclic");
+    }
     // copy back to original array
     for (int i = 0; i < ss->n_conds; i++) {
         ss->conds[i] = reordered_conds[i];

--- a/tests/testthat/test_OptimizerBatchLocalSearch.R
+++ b/tests/testthat/test_OptimizerBatchLocalSearch.R
@@ -435,3 +435,14 @@ test_that("OptimizerBatchLocalSearch works with CondAnyOf", {
   }
   if (nrow(dt[x1 %in% c("a", "b")])) expect_true(all(!is.na(dt[x1 %in% c("a", "b")]$x2)))
 })
+
+test_that("local_search errors on invalid control values instead of aborting", {
+  search_space = ps(x = p_dbl(-1, 1))
+  control = local_search_control(n_searches = 2L, n_steps = 1L, n_neighs = 2L, mut_sd = 0)
+  init_points = data.table(x = c(-0.5, 0.5))
+
+  expect_error(
+    local_search(function(xdt) xdt$x^2, search_space, control, init_points),
+    "mut_sd"
+  )
+})


### PR DESCRIPTION
## Problem

`src/local_search.c` contained eight `assert()` calls:

* the unsupported column type fallback in `dt_is_na()`,
* the "element is not NA" precondition of `dt_mutate_element()`,
* the four control value checks in `extract_ctrl_info()`,
* the completeness checks in `toposort_params()` and `reorder_conds_by_toposort()`.

`assert()` is the wrong tool in package C code: it aborts the whole R session, and it is compiled out entirely in a build with `-DNDEBUG`, so the invalid state is then used instead of being caught.

`local_search_control(mut_sd = 0)` passes the R side checks (`assert_number(mut_sd, lower = 0)`) and reached `assert(ctrl->mut_sd > 0)`, i.e. an aborted session for an ordinary user mistake.

## Fix

Every assertion becomes an `Rf_error()` that says what is wrong, and `<assert.h>` is no longer included.

## Tests

New regression test: `local_search_control(mut_sd = 0)` produces an R error mentioning `mut_sd` instead of aborting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)