### PR TITLE
fix: fail the point instead of the worker on an objective error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: An error in the objective of an asynchronous optimization now moves the point to the failed points instead of killing the worker (#383).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimInstanceAsync.R
+++ b/R/OptimInstanceAsync.R
@@ -112,7 +112,19 @@ OptimInstanceAsync = R6Class(
 
       # eval
       key = self$archive$push_running_point(private$.xs)
-      private$.ys = self$objective$eval(private$.xs_trafoed)
+      private$.ys = tryCatch(
+        self$objective$eval(private$.xs_trafoed),
+        error = function(cond) {
+          # a failing objective must not kill the worker, the point is moved to the failed points instead
+          lg$info("Evaluation of point failed: %s", conditionMessage(cond))
+          self$archive$fail_point(key, condition = cond)
+          NULL
+        }
+      )
+
+      if (is.null(private$.ys)) {
+        return(invisible(NULL))
+      }
 
       call_back("on_optimizer_after_eval", self$objective$callbacks, self$objective$context)
 
@@ -134,12 +146,22 @@ OptimInstanceAsync = R6Class(
           call_back("on_optimizer_queue_before_eval", self$objective$callbacks, self$objective$context)
 
           # eval
-          private$.ys = self$objective$eval(private$.xs_trafoed)
+          private$.ys = tryCatch(
+            self$objective$eval(private$.xs_trafoed),
+            error = function(cond) {
+              # a failing objective must not kill the worker, the point is moved to the failed points instead
+              lg$info("Evaluation of queued point failed: %s", conditionMessage(cond))
+              self$archive$fail_point(task$key, condition = cond)
+              NULL
+            }
+          )
 
-          call_back("on_optimizer_queue_after_eval", self$objective$callbacks, self$objective$context)
+          if (!is.null(private$.ys)) {
+            call_back("on_optimizer_queue_after_eval", self$objective$callbacks, self$objective$context)
 
-          # push result
-          self$archive$finish_point(task$key, private$.ys, x_domain = private$.xs_trafoed)
+            # push result
+            self$archive$finish_point(task$key, private$.ys, x_domain = private$.xs_trafoed)
+          }
         }
       }
     },

--- a/tests/testthat/test_OptimInstanceAsyncSingleCrit.R
+++ b/tests/testthat/test_OptimInstanceAsyncSingleCrit.R
@@ -129,3 +129,59 @@ test_that("tiny logging works", {
   optimizer = opt("async_random_search")
   expect_data_table(optimizer$optimize(instance))
 })
+
+test_that("an objective error fails the point instead of the worker", {
+  rush = start_rush_worker()
+  on.exit(rush$reset())
+
+  objective = ObjectiveRFun$new(
+    fun = function(xs) {
+      if (xs$x1 > 0.5) stop("objective failed")
+      list(y = xs$x1 + xs$x2)
+    },
+    domain = PS_2D_domain,
+    properties = "single-crit"
+  )
+
+  instance = oi_async(
+    objective = objective,
+    search_space = ps(x1 = p_dbl(0, 1), x2 = p_dbl(0, 1)),
+    terminator = trm("evals", n_evals = 10L),
+    rush = rush
+  )
+
+  expect_null(get_private(instance)$.eval_point(list(x1 = 0.9, x2 = 0.1)))
+  expect_equal(instance$archive$n_failed, 1L)
+  expect_equal(instance$archive$n_finished, 0L)
+
+  expect_equal(get_private(instance)$.eval_point(list(x1 = 0.1, x2 = 0.2)), list(y = 0.3))
+  expect_equal(instance$archive$n_failed, 1L)
+  expect_equal(instance$archive$n_finished, 1L)
+})
+
+test_that("an objective error fails a queued point instead of the worker", {
+  rush = start_rush_worker()
+  on.exit(rush$reset())
+
+  objective = ObjectiveRFun$new(
+    fun = function(xs) {
+      if (xs$x1 > 0.5) stop("objective failed")
+      list(y = xs$x1 + xs$x2)
+    },
+    domain = PS_2D_domain,
+    properties = "single-crit"
+  )
+
+  instance = oi_async(
+    objective = objective,
+    search_space = ps(x1 = p_dbl(0, 1), x2 = p_dbl(0, 1)),
+    terminator = trm("evals", n_evals = 10L),
+    rush = rush
+  )
+  instance$archive$push_points(list(list(x1 = 0.9, x2 = 0.1), list(x1 = 0.1, x2 = 0.2)))
+
+  get_private(instance)$.eval_queue()
+
+  expect_equal(instance$archive$n_failed, 1L)
+  expect_equal(instance$archive$n_finished, 1L)
+})

--- a/tests/testthat/test_OptimizerAsync.R
+++ b/tests/testthat/test_OptimizerAsync.R
@@ -41,7 +41,7 @@ test_that("OptimizerAsync assigns result", {
   expect_data_table(instance$result, nrows = 1)
 })
 
-test_that("OptimizerAsync throws an error when all workers are lost", {
+test_that("OptimizerAsync throws an error when no evaluation finished", {
   rush = start_rush()
   on.exit({
     rush$reset()
@@ -280,3 +280,4 @@ test_that("OptimizerAsync passes the compute profile to the optimizer", {
   expect_subset(instance$archive$data$.profile, c("cpu", "gpu", NA))
   expect_true(all(c("cpu", "gpu") %in% instance$archive$data$.profile))
 })
+


### PR DESCRIPTION
## Problem

```r
key = self$archive$push_running_point(private$.xs)
private$.ys = self$objective$eval(private$.xs_trafoed)
```

No `tryCatch()`, so an objective error propagates out of `.optimize()` and out of `bbotk_worker_loop()`, and rush declares the worker lost.

With two workers, an objective that errors when `x1 > 0.5`, and `n_evals = 50`, both workers were dead within a second, nothing finished, and `$optimize()` aborted with "Optimization terminated without any finished evaluations".
`ArchiveAsync$fail_point()` exists for precisely this case and was dead code in the async path.

## Fix

Catch the error in `.eval_point()` and `.eval_queue()`, log it, and move the running point to the failed points with `$fail_point(key, condition = cond)`.
`on_optimizer_after_eval` and `$finish_point()` are skipped for a failed point, and `.eval_point()` returns `NULL`.

Failed points count towards `ArchiveAsync$n_evals`, so terminators keep making progress and an objective that always fails still ends in the existing "without any finished evaluations" error — the existing test for that case still passes (its title is updated, since the workers are no longer lost).

## Tests

Two regression tests driving `.eval_point()` and `.eval_queue()` on a `RushWorker` in the main process: a failing point ends up in the failed points, the next point still finishes, and the counters add up.

They deliberately do not go through real workers: with `devtools::load_all()` the daemons load the *installed* bbotk, so an end-to-end test would silently exercise the old code locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)