### PR TITLE
fix: stop async workers on every exit path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `optimize_async_default()` now stops the workers on every exit path, including errors and interrupts. A failing optimization left the workers running before (#384).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimizerAsync.R
+++ b/R/OptimizerAsync.R
@@ -139,8 +139,7 @@ optimize_async_default = function(instance, optimizer, design = NULL, n_workers 
     instance$archive$push_points(transpose_list(design))
   }
 
-  # the workers must be stopped on every exit path, e.g. an error while waiting for the workers or while logging the
-  # results, an error in `.assign_result()`, or an interrupt by the user
+  # the workers must be stopped on every exit path
   on.exit(instance$rush$stop_workers(type = "kill"), add = TRUE)
 
   if (getOption("bbotk.debug", FALSE)) {

--- a/R/OptimizerAsync.R
+++ b/R/OptimizerAsync.R
@@ -139,6 +139,10 @@ optimize_async_default = function(instance, optimizer, design = NULL, n_workers 
     instance$archive$push_points(transpose_list(design))
   }
 
+  # the workers must be stopped on every exit path, e.g. an error while waiting for the workers or while logging the
+  # results, an error in `.assign_result()`, or an interrupt by the user
+  on.exit(instance$rush$stop_workers(type = "kill"), add = TRUE)
+
   if (getOption("bbotk.debug", FALSE)) {
     # debug mode runs .optimize() in main process
     rush = rush::RushWorker$new(instance$rush$network_id)
@@ -267,7 +271,6 @@ optimize_async_default = function(instance, optimizer, design = NULL, n_workers 
   }
 
   call_back("on_optimization_end", instance$objective$callbacks, instance$objective$context)
-  instance$rush$stop_workers(type = "kill")
   return(instance$result)
 }
 

--- a/tests/testthat/test_OptimizerAsync.R
+++ b/tests/testthat/test_OptimizerAsync.R
@@ -280,3 +280,31 @@ test_that("OptimizerAsync passes the compute profile to the optimizer", {
   expect_subset(instance$archive$data$.profile, c("cpu", "gpu", NA))
   expect_true(all(c("cpu", "gpu") %in% instance$archive$data$.profile))
 })
+
+test_that("workers are stopped when the optimization errors", {
+  rush = start_rush(n_workers = 1)
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  objective = ObjectiveRFun$new(
+    fun = function(xs) {
+      Sys.sleep(10)
+      list(y = xs$x1)
+    },
+    domain = PS_2D_domain,
+    properties = "single-crit"
+  )
+
+  instance = oi_async(
+    objective = objective,
+    search_space = PS_2D,
+    terminator = trm("run_time", secs = 2),
+    rush = rush
+  )
+
+  optimizer = opt("async_random_search")
+  expect_error(optimizer$optimize(instance), "without any finished evaluations")
+  expect_equal(rush$n_running_workers, 0L)
+})


### PR DESCRIPTION
## Problem

`optimize_async_default()` ended with

```r
call_back("on_optimization_end", ...)
instance$rush$stop_workers(type = "kill")
return(instance$result)
```

Every path that does not reach the last statement leaks the workers:

* the `stopf("Optimization terminated without any finished evaluations.")` above it — reproducible with a slow objective and `trm("run_time", secs = 2)`, which leaves a worker executing,
* an error while printing the results or inside `.assign_result()`,
* Ctrl-C.

## Fix

Register `on.exit(instance$rush$stop_workers(type = "kill"), add = TRUE)` before the workers are started, so an error in `wait_for_workers()` is covered as well, and drop the trailing call.
`stop_workers()` on a controller without workers is a no-op, so the debug mode path is unaffected.

## Tests

New regression test: a slow objective with `trm("run_time", secs = 2)` errors as before, and `rush$n_running_workers` is 0 afterwards. Without the fix, it is 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)