### PR TITLE
fix: mark the local worker as terminated in debug mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `options(bbotk.debug = TRUE)` no longer hangs when the optimizer returns before the terminator is satisfied, e.g. when the design of `OptimizerAsyncDesignPoints` is exhausted (#385).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimizerAsync.R
+++ b/R/OptimizerAsync.R
@@ -152,6 +152,9 @@ optimize_async_default = function(instance, optimizer, design = NULL, n_workers 
     get_private(optimizer)$.optimize(instance)
 
     call_back("on_worker_end", instance$objective$callbacks, instance$objective$context)
+
+    # the local worker is done, otherwise it is counted as running forever and the wait loop below never breaks
+    rush$set_terminated()
   } else {
     # run .optimize() on workers
     rush = instance$rush

--- a/tests/testthat/test_OptimizerAsync.R
+++ b/tests/testthat/test_OptimizerAsync.R
@@ -280,3 +280,26 @@ test_that("OptimizerAsync passes the compute profile to the optimizer", {
   expect_subset(instance$archive$data$.profile, c("cpu", "gpu", NA))
   expect_true(all(c("cpu", "gpu") %in% instance$archive$data$.profile))
 })
+
+test_that("debug mode terminates when the design is exhausted", {
+  rush = start_rush(n_workers = 1)
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+    options(bbotk.debug = FALSE)
+  })
+  options(bbotk.debug = TRUE)
+
+  instance = oi_async(
+    objective = OBJ_2D,
+    search_space = PS_2D,
+    terminator = trm("evals", n_evals = 20L),
+    rush = rush
+  )
+
+  optimizer = opt("async_design_points", design = data.table(x1 = c(0, 0.5), x2 = c(0, 0.5)))
+  optimizer$optimize(instance)
+
+  expect_equal(instance$archive$n_finished, 2L)
+  expect_data_table(instance$result, nrows = 1L)
+})


### PR DESCRIPTION
## Problem

```r
if (getOption("bbotk.debug", FALSE)) {
  rush = rush::RushWorker$new(instance$rush$network_id)
  ...
  get_private(optimizer)$.optimize(instance)
  ...
}
```

The `RushWorker` registers itself as a running worker and is never removed, so `rush$n_running_workers` is permanently 1.
The wait loop below only leaves when the terminator is satisfied or when no worker is running, so as soon as `.optimize()` returns before the terminator fires, `$optimize()` spins forever:

```r
options(bbotk.debug = TRUE)
opt("async_design_points", design = data.table(x1 = c(0, 0.5), x2 = c(0, 0.5)))$optimize(instance)  # n_evals = 20
```

## Fix

Call `rush$set_terminated()` after the optimizer loop, which is what a real worker does at the end of its loop. The wait loop then takes its "All workers have terminated." exit.

## Tests

New regression test: debug mode with a two-row design and `n_evals = 20` returns, finishes two evaluations, and assigns a result. Without the fix the test hangs (verified with a timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)