### PR TITLE
fix: check instance properties for async optimizers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `optimize_async_default()` now checks the instance and the properties of the optimizer before the workers are started, so unsupported parameter classes, dependencies, single or multi-criteria mismatches, and missing packages are reported in the main process instead of crashing the workers (#386).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/OptimizerAsync.R
+++ b/R/OptimizerAsync.R
@@ -116,6 +116,8 @@ OptimizerAsync = R6Class(
 #' @keywords internal
 #' @export
 optimize_async_default = function(instance, optimizer, design = NULL, n_workers = NULL, profiles = NULL) {
+  assert_instance_async(instance)
+  assert_instance_properties(optimizer, instance)
   assert_data_table(design, null.ok = TRUE)
   assert_count(n_workers, null.ok = TRUE)
   profiles = rush::assert_profiles(profiles)

--- a/tests/testthat/test_OptimizerAsync.R
+++ b/tests/testthat/test_OptimizerAsync.R
@@ -280,3 +280,28 @@ test_that("OptimizerAsync passes the compute profile to the optimizer", {
   expect_subset(instance$archive$data$.profile, c("cpu", "gpu", NA))
   expect_true(all(c("cpu", "gpu") %in% instance$archive$data$.profile))
 })
+
+test_that("OptimizerAsync checks the properties of the instance", {
+  rush = start_rush(n_workers = 1)
+  on.exit({
+    rush$reset()
+    mirai::daemons(0)
+  })
+
+  instance = oi_async(
+    objective = OBJ_1D,
+    search_space = PS_1D_domain,
+    terminator = trm("evals", n_evals = 5L),
+    rush = rush
+  )
+
+  optimizer = opt("async_random_search")
+  expect_error(optimizer$optimize(instance), "does not support param types")
+})
+
+test_that("OptimizerAsync rejects a batch instance", {
+  instance = MAKE_INST_1D(trm("evals", n_evals = 5L))
+
+  optimizer = opt("async_random_search")
+  expect_error(optimizer$optimize(instance), "OptimInstanceAsync")
+})


### PR DESCRIPTION
## Problem

`optimize_batch_default()` starts with

```r
assert_instance_properties(optimizer, instance)
```

`optimize_async_default()` had no such check, so everything that assertion catches was deferred to the workers:

* a search space with an unsupported parameter class (e.g. `ParamUty` for `async_random_search`),
* dependencies in the search space for an optimizer without the `"dependencies"` property,
* a single/multi-criteria mismatch,
* a missing package (`require_namespaces(optimizer$packages)`).

All of them appeared as worker crashes, i.e. "Optimization terminated without any finished evaluations" plus a lost-worker log line.
Passing a *batch* instance to an async optimizer failed with `attempt to apply non-function`.

## Fix

Call `assert_instance_async(instance)` and `assert_instance_properties(optimizer, instance)` at the top of `optimize_async_default()`.

## Tests

* an async instance with a `ParamUty` search space errors with "does not support param types",
* a batch instance passed to `opt("async_random_search")` errors naming `OptimInstanceAsync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)