### PR TITLE
fix: copy before sorting in ArchiveAsync$best()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * refactor: `OptimizerBatchCmaes` now calls `libcmaesr::cmaes()` instead of `adagio::pureCMAES()`, which is no longer suggested. The optimizer gains the `algo`, `lambda`, `max_restarts`, `elitism`, `tpa`, `tpa_dsigma`, `seed`, `f_tolerance`, `x_tolerance`, `x0_lower`, and `x0_upper` parameters, and evaluates a whole generation of `lambda` points per batch. The `sigma` parameter no longer defaults to `0.5` but is handled by `libcmaes`.
 
+* fix: `ArchiveAsync$best()` with `n_select > 1` no longer reorders the task cache of rush in place, which changed the order of `$finished_data` and `$data` for all later calls (#387).
+
 * feat: Asynchronous optimizers support the `mirai` compute profiles set with the `profiles` argument of `rush::rush_plan()`,
   e.g. `profiles = c(cpu = 2, gpu = 2)` runs 2 workers on the daemons of the `"cpu"` profile and 2 workers on the daemons of the `"gpu"` profile.
   The profile a worker runs on is available as `instance$rush$profile`.

--- a/R/ArchiveAsync.R
+++ b/R/ArchiveAsync.R
@@ -397,6 +397,8 @@ ArchiveAsync = R6Class(
           ii = which_max(y, ties_method = ties_method)
           tab[ii]
         } else {
+          # `finished_data` is the cache of rush, so we copy before sorting
+          tab = copy(tab)
           # use data.table fast sort to find the best points
           setorderv(tab, cols = self$cols_y, order = self$codomain$direction)
           head(tab, n_select)

--- a/tests/testthat/test_ArchiveAsync.R
+++ b/tests/testthat/test_ArchiveAsync.R
@@ -475,3 +475,31 @@ test_that("push_result is deprecated and forwards to finish_point", {
 
   expect_data_table(archive$finished_data, nrows = 1)
 })
+
+test_that("best method does not reorder the cache of rush", {
+  rush = start_rush_worker()
+  on.exit(rush$reset())
+
+  archive = ArchiveAsync$new(
+    search_space = PS_2D,
+    codomain = FUN_2D_CODOMAIN,
+    rush = rush
+  )
+
+  xss = list(list(x1 = 1, x2 = 1), list(x1 = 0, x2 = 0), list(x1 = 0.5, x2 = 0.5))
+  keys = archive$push_points(xss)
+  for (i in seq_along(keys)) {
+    archive$pop_point()
+  }
+  ys = list(3, 1, 2)
+  for (i in seq_along(keys)) {
+    archive$finish_point(keys[[i]], ys = list(y = ys[[i]]), x_domain = xss[[i]])
+  }
+
+  # the columns of the cache are permuted in place, so we need a real copy to compare against
+  before = copy(archive$finished_data)
+  expect_equal(before$y, c(3, 1, 2))
+
+  expect_equal(archive$best(n_select = 2L)$y, c(1, 2))
+  expect_equal(archive$finished_data$y, before$y)
+})


### PR DESCRIPTION
## Problem

```r
tab = self$finished_data
...
setorderv(tab, cols = self$cols_y, order = self$codomain$direction)
```

`$finished_data` is `rush$fetch_finished_tasks()`, which ends in `private$.cached_tasks[]`, i.e. the cache **by reference**.
`setorderv()` therefore permutes rush's cache in place, and every later `$finished_data`, `$data`, and `$best()` call sees the reordered table — which also silently changes what `ties_method = "first"` means.

`ArchiveBatch$best()` does `tab = copy(self$data)` before sorting for exactly this reason.

Confirmed (the review listed it as plausible): the new test fails without the fix, with `$finished_data$y` coming back as `1, 2, 3` instead of the insertion order `3, 1, 2`.

## Fix

Copy inside the `n_select > 1` branch, so the common `n_select == 1` path stays copy-free.

## Tests

New regression test: three finished points, `$best(n_select = 2)` returns the two best, and `$finished_data` keeps its original order afterwards.
The comparison snapshot needs `copy()`: `setorderv()` permutes the column vectors in place, so a plain `archive$finished_data$y` reference changes along with the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)